### PR TITLE
[Feature/YDS-3-2] YDSColor extension에서 Enum으로 변경

### DIFF
--- a/YDS-iOS/Foundation/BasicColor.swift
+++ b/YDS-iOS/Foundation/BasicColor.swift
@@ -25,8 +25,7 @@ fileprivate extension UIColor{
     }
 }
 
-internal class BasicColor {
-    
+internal enum BasicColor {
     static var logoBlue: UIColor {
         return UIColor(hex: "#1653DB")
     }

--- a/YDS-iOS/Foundation/SemanticColor.swift
+++ b/YDS-iOS/Foundation/SemanticColor.swift
@@ -6,10 +6,7 @@
 //
 import UIKit
 
-public class YDSColor {
-    
-    private init(){}
-    
+public enum YDSColor {
     private static func color(light: UIColor, dark: UIColor? = nil) -> UIColor {
        if let dark = dark  {
            if #available(iOS 13.0, *) {


### PR DESCRIPTION
- UIColor Extension 이용시 UIColor와 혼동될 수 있지만 YDSColor Enum는  출처가 명확하기 때문에 이를 보완할 수 있습니다.
- 컬러 사용법은 YDSColor.bgNormal 입니다.

- 리뷰 해주시고 다른 방안이 생각난다면 dev-ios 슬랙에 남겨주세요