### PR TITLE
[Feature/YDS-78] TypoStyle 정의 수정 및 Typography 페이지 작성

### DIFF
--- a/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListItemCell.swift
+++ b/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListItemCell.swift
@@ -1,0 +1,23 @@
+//
+//  TypographiesListItemCell.swift
+//  YDS-Storybook
+//
+//  Created by Gyuni on 2021/09/14.
+//
+
+import UIKit
+
+class TypographiesListItemCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListItemCell.swift
+++ b/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListItemCell.swift
@@ -173,9 +173,15 @@ fileprivate class TypographiesListItemCellDescriptionRow: UIView {
     }
     
     private func setupViews() {
-        
+        setViewHierarchy()
+        setAutolayout()
+    }
+    
+    private func setViewHierarchy() {
         self.addSubviews(categoryLabel, propertyLabel)
-        
+    }
+    
+    private func setAutolayout() {
         self.snp.makeConstraints {
             $0.height.equalTo(Dimension.height)
         }
@@ -191,7 +197,6 @@ fileprivate class TypographiesListItemCellDescriptionRow: UIView {
             $0.trailing.equalToSuperview()
             $0.top.bottom.equalToSuperview()
         }
-        
     }
     
 }

--- a/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListItemCell.swift
+++ b/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListItemCell.swift
@@ -6,18 +6,192 @@
 //
 
 import UIKit
+import YDS
 
 class TypographiesListItemCell: UITableViewCell {
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
+    private enum Dimension {
+        enum Padding {
+            static let vertical: CGFloat = 16
+            static let horizontal: CGFloat = 20
+        }
+        
+        enum Description {
+            enum Padding {
+                static let vertical: CGFloat = 8
+                static let horizontal: CGFloat = 20
+            }
+        }
+    }
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 12
+        stackView.alignment = .fill
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = UIEdgeInsets(top: Dimension.Padding.vertical,
+                                               left: Dimension.Padding.horizontal,
+                                               bottom: Dimension.Padding.vertical,
+                                               right: Dimension.Padding.horizontal)
+        return stackView
+    }()
+    
+    private let badge = YDSBadge()
+    
+    private let sampleLabel: YDSLabel = {
+        let label = YDSLabel(style: .body1)
+        label.textColor = YDSColor.textPrimary
+        label.numberOfLines = 0
+        label.text = """
+        계절이 지나가는 하늘에는 가을로 가득 차 있습니다.
+        나는 아무 걱정도 없이 가을 속의 별들을 다 헬 듯합니다.
+        가슴 속에 하나 둘 새겨지는 별을 이제 다 못 헤는 것은 쉬이 아침이 오는 까닭이요, 내일 밤이 남은 까닭이요, 아직 나의 청춘이 다하지 않은 까닭입니다.
+        """
+        return label
+    }()
+    
+    private let descriptionStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = UIEdgeInsets(top: Dimension.Description.Padding.vertical,
+                                               left: Dimension.Description.Padding.horizontal,
+                                               bottom: Dimension.Description.Padding.vertical,
+                                               right: Dimension.Description.Padding.horizontal)
+        
+        stackView.backgroundColor = YDSColor.monoItemBG
+        stackView.layer.cornerRadius = 8
+        stackView.clipsToBounds = true
+        return stackView
+    }()
+    
+    private let sizeDescriptionRow: TypographiesListItemCellDescriptionRow = {
+        let row = TypographiesListItemCellDescriptionRow()
+        row.category = "size"
+        return row
+    }()
+    
+    private let weightDescriptionRow: TypographiesListItemCellDescriptionRow = {
+        let row = TypographiesListItemCellDescriptionRow()
+        row.category = "weight"
+        return row
+    }()
+    
+    private let lineHeightDescriptionRow: TypographiesListItemCellDescriptionRow = {
+        let row = TypographiesListItemCellDescriptionRow()
+        row.category = "lineHeight"
+        return row
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupViews() {
+        setViewProperties()
+        setViewHierarchy()
+        setAutolayout()
+    }
+    
+    private func setViewProperties() {
+        self.selectionStyle = .none
+    }
+    
+    private func setViewHierarchy() {
+        self.addSubview(stackView)
+        stackView.addArrangedSubviews(badge,
+                                      sampleLabel,
+                                      descriptionStackView)
+        descriptionStackView.addArrangedSubviews(sizeDescriptionRow,
+                                                 weightDescriptionRow,
+                                                 lineHeightDescriptionRow)
+    }
+    
+    private func setAutolayout() {
+        stackView.snp.makeConstraints {
+            $0.top.bottom.leading.trailing.equalToSuperview()
+        }
+    }
+    
+    func fillData(with model: String.TypoStyle) {
+        badge.text = String(describing: model)
+        sampleLabel.style = model
+        sizeDescriptionRow.property = String(format: "%.0f", model.font.pointSize) + "pt"
+        weightDescriptionRow.property = model.font.fontDescriptor.object(forKey: UIFontDescriptor.AttributeName.face) as? String
+        lineHeightDescriptionRow.property = String(format: "%.0f", 100*model.lineHeight) + "%"
+        
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
+}
 
-        // Configure the view for the selected state
+fileprivate class TypographiesListItemCellDescriptionRow: UIView {
+    
+    var category: String? {
+        get { return categoryLabel.text }
+        set { categoryLabel.text = newValue }
     }
-
+    
+    var property: String? {
+        get { return propertyLabel.text }
+        set { propertyLabel.text = newValue }
+    }
+    
+    private let categoryLabel: YDSLabel = {
+        let label = YDSLabel(style: .subtitle3)
+        label.textColor = YDSColor.textTertiary
+        return label
+    }()
+    
+    private let propertyLabel: YDSLabel = {
+        let label = YDSLabel(style: .body2)
+        label.textColor = YDSColor.monoItemText
+        return label
+    }()
+    
+    private enum Dimension {
+        static let height: CGFloat = 32
+        static let categoryLabelWidth: CGFloat = 100
+    }
+    
+    init() {
+        super.init(frame: .zero)
+        
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupViews() {
+        
+        self.addSubviews(categoryLabel, propertyLabel)
+        
+        self.snp.makeConstraints {
+            $0.height.equalTo(Dimension.height)
+        }
+        
+        categoryLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.width.equalTo(Dimension.categoryLabelWidth)
+            $0.top.bottom.equalToSuperview()
+        }
+        
+        propertyLabel.snp.makeConstraints {
+            $0.leading.equalTo(categoryLabel.snp.trailing)
+            $0.trailing.equalToSuperview()
+            $0.top.bottom.equalToSuperview()
+        }
+        
+    }
+    
 }

--- a/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListTableViewController.swift
+++ b/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListTableViewController.swift
@@ -1,0 +1,89 @@
+//
+//  TypographiesTableViewController.swift
+//  YDS-Storybook
+//
+//  Created by Gyuni on 2021/09/14.
+//
+
+import UIKit
+
+class TypographiesTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListTableViewController.swift
+++ b/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListTableViewController.swift
@@ -8,82 +8,52 @@
 import UIKit
 
 class TypographiesTableViewController: UITableViewController {
-
+    
+    private var model: [[String]]
+    
+    init(with model: [[String]]) {
+        self.model = model
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+        setupViews()
+    }
+    
+    private func setupViews() {
+        setViewProperties()
+    }
+    
+    private func setViewProperties() {
+        self.tableView.register(TypographiesListItemCell.self, forCellReuseIdentifier: TypographiesListItemCell.reuseIdentifier)
+        self.tableView.separatorStyle = .none
     }
 
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 0
+        return model.count
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return model[section][0]
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // #warning Incomplete implementation, return the number of rows
-        return 0
+        return model[section].count
     }
 
-    /*
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
-
-        // Configure the cell...
+        let cell: TypographiesListItemCell = tableView.dequeueReusableCell(for: indexPath)
 
         return cell
     }
-    */
-
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
-    }
-    */
-
-    /*
-    // Override to support editing the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            // Delete the row from the data source
-            tableView.deleteRows(at: [indexPath], with: .fade)
-        } else if editingStyle == .insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }    
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
+    
 }

--- a/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListTableViewController.swift
+++ b/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListTableViewController.swift
@@ -1,17 +1,18 @@
 //
-//  TypographiesTableViewController.swift
+//  TypographiesListTableViewController.swift
 //  YDS-Storybook
 //
 //  Created by Gyuni on 2021/09/14.
 //
 
 import UIKit
+import YDS
 
-class TypographiesTableViewController: UITableViewController {
+class TypographiesListTableViewController: UITableViewController {
     
-    private var model: [[String]]
+    private var model: [Typographies]
     
-    init(with model: [[String]]) {
+    init(with model: [Typographies]) {
         self.model = model
         super.init(nibName: nil, bundle: nil)
     }
@@ -32,27 +33,25 @@ class TypographiesTableViewController: UITableViewController {
     
     private func setViewProperties() {
         self.tableView.register(TypographiesListItemCell.self, forCellReuseIdentifier: TypographiesListItemCell.reuseIdentifier)
-        self.tableView.separatorStyle = .none
+        self.tableView.separatorColor = YDSColor.borderNormal
     }
 
-    // MARK: - Table view data source
-
+    // MARK: - DataSource
     override func numberOfSections(in tableView: UITableView) -> Int {
         return model.count
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return model[section][0]
+        return model[section].description
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
-        return model[section].count
+        return model[section].items.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: TypographiesListItemCell = tableView.dequeueReusableCell(for: indexPath)
-
+        cell.fillData(with: model[indexPath.section].items[indexPath.row])
         return cell
     }
     

--- a/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesPageViewController.swift
+++ b/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesPageViewController.swift
@@ -1,5 +1,5 @@
 //
-//  TypoPageViewController.swift
+//  TypographiesPageViewController.swift
 //  YDS-Storybook
 //
 //  Created by Gyuni on 2021/09/14.
@@ -7,23 +7,46 @@
 
 import UIKit
 
-class TypoPageViewController: UIViewController {
+class TypographiesPageViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    private let typographiesListTableViewController: TypographiesListTableViewController
+    
+    init() {
+        typographiesListTableViewController = TypographiesListTableViewController(with: typographies)
+        
+        super.init(nibName: nil, bundle: nil)
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-    */
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupView()
+    }
+
+    private func setupView() {
+        setViewProperties()
+        setViewHierarchy()
+        setAutolayout()
+    }
+    
+    private func setViewProperties() {
+        self.title = "Typography"
+    }
+    
+    private func setViewHierarchy() {
+        self.embed(typographiesListTableViewController)
+        self.view.addSubview(typographiesListTableViewController.view)
+    }
+    
+    private func setAutolayout() {
+        typographiesListTableViewController.view.snp.makeConstraints {
+            $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.bottom.equalToSuperview()
+        }
+    }
 
 }

--- a/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesPageViewController.swift
+++ b/YDS-Storybook/FoundationSampleViewController/Typography/TypographiesPageViewController.swift
@@ -1,0 +1,29 @@
+//
+//  TypoPageViewController.swift
+//  YDS-Storybook
+//
+//  Created by Gyuni on 2021/09/14.
+//
+
+import UIKit
+
+class TypoPageViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/YDS-Storybook/PageListViewController.swift
+++ b/YDS-Storybook/PageListViewController.swift
@@ -16,7 +16,7 @@ class PageListViewController: UIViewController {
     //  MARK: - tableView에 들어갈 섹션과 셀에 대한 코드입니다.
     
     //  각 섹션의 타이틀로 사용될 문자열입니다.
-    let sections: [String] = ["0. Rule", "1. Foundation", "2. Atom", "3. Component"]
+    let sections: [String] = ["1. Foundation", "2. Atom", "3. Component"]
     
     
     //  title은 cell에 표시되는 글자입니다.
@@ -28,9 +28,6 @@ class PageListViewController: UIViewController {
     
     
     //  여기 아래에 각 단계에 맞는 Page를 추가해주세요.
-    let rulePages: [Page] = [
-        Page(title: "Sample", vc: UIViewController.self),
-    ]
     
     let foundationPages: [Page] = [
         Page(title: "Color", vc: ColorsPageViewController.self),
@@ -126,12 +123,10 @@ extension PageListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch(section) {
         case 0:
-            return rulePages.count
-        case 1:
             return foundationPages.count
-        case 2:
+        case 1:
             return atomPages.count
-        case 3:
+        case 2:
             return componentPages.count
         default:
             return 0
@@ -143,12 +138,10 @@ extension PageListViewController: UITableViewDataSource {
         
         switch(indexPath.section) {
         case 0:
-            page = rulePages[indexPath.row]
-        case 1:
             page = foundationPages[indexPath.row]
-        case 2:
+        case 1:
             page = atomPages[indexPath.row]
-        case 3:
+        case 2:
             page = componentPages[indexPath.row]
         default:
             page = Page(title: "error", vc: UIViewController.self)

--- a/YDS-Storybook/PageListViewController.swift
+++ b/YDS-Storybook/PageListViewController.swift
@@ -34,6 +34,7 @@ class PageListViewController: UIViewController {
     
     let foundationPages: [Page] = [
         Page(title: "Color", vc: ColorsPageViewController.self),
+        Page(title: "Typography", vc: TypographiesPageViewController.self),
     ]
     
     let atomPages: [Page] = [

--- a/YDS-Storybook/Resources/YDSTypographyArray.swift
+++ b/YDS-Storybook/Resources/YDSTypographyArray.swift
@@ -6,8 +6,6 @@
 //
 
 import YDS
-import Foundation
-import UIKit
 
 struct Typographies {
     let items: [String.TypoStyle]

--- a/YDS-Storybook/Resources/YDSTypographyArray.swift
+++ b/YDS-Storybook/Resources/YDSTypographyArray.swift
@@ -1,0 +1,8 @@
+//
+//  YDSTypographyArray.swift
+//  YDS-Storybook
+//
+//  Created by Gyuni on 2021/09/14.
+//
+
+import Foundation

--- a/YDS-Storybook/Resources/YDSTypographyArray.swift
+++ b/YDS-Storybook/Resources/YDSTypographyArray.swift
@@ -5,4 +5,54 @@
 //  Created by Gyuni on 2021/09/14.
 //
 
+import YDS
 import Foundation
+import UIKit
+
+struct Typographies {
+    let items: [String.TypoStyle]
+    let description: String?
+}
+
+let titleTypographies = Typographies(
+    items: [
+        .title1, .title2, .title3
+    ],
+    description: "Title"
+)
+
+let subtitleTypographies = Typographies(
+    items: [
+        .subtitle1, .subtitle2, .subtitle3
+    ],
+    description: "Subtitle"
+)
+
+let bodyTypographies = Typographies(
+    items: [
+        .body1, .body2
+    ],
+    description: "Body"
+)
+
+let buttonTypographies = Typographies(
+    items: [
+        .button0, .button1, .button2, .button3, .button4
+    ],
+    description: "Button"
+)
+
+let captionTypographies = Typographies(
+    items: [
+        .caption1, .caption2
+    ],
+    description: "Caption"
+)
+
+let typographies = [
+    titleTypographies,
+    subtitleTypographies,
+    bodyTypographies,
+    buttonTypographies,
+    captionTypographies
+]

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -76,6 +76,10 @@
 		53C9F70426B5BC1A00EF7B86 /* YDSProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C9F70326B5BC1A00EF7B86 /* YDSProfileImageView.swift */; };
 		53C9F70626B5BCCE00EF7B86 /* ProfileImageViewPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C9F70526B5BCCE00EF7B86 /* ProfileImageViewPageViewController.swift */; };
 		53C9F70C26B67CE900EF7B86 /* YDSCheckbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C9F70B26B67CE900EF7B86 /* YDSCheckbox.swift */; };
+		53E26E8626F0619E0036648E /* TypographiesPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E26E8526F0619E0036648E /* TypographiesPageViewController.swift */; };
+		53E26E8826F061F80036648E /* TypographiesListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E26E8726F061F80036648E /* TypographiesListTableViewController.swift */; };
+		53E26E8A26F062180036648E /* TypographiesListItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E26E8926F062180036648E /* TypographiesListItemCell.swift */; };
+		53E26E8C26F0637A0036648E /* YDSTypographyArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E26E8B26F0637A0036648E /* YDSTypographyArray.swift */; };
 		53E2CF3C26D29F62000DE005 /* SimpleTextFieldViewPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E2CF3B26D29F62000DE005 /* SimpleTextFieldViewPageViewController.swift */; };
 		53E2CF3E26D2A1ED000DE005 /* SuffixTextFieldViewPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E2CF3D26D2A1ED000DE005 /* SuffixTextFieldViewPageViewController.swift */; };
 		53E2CF4026D2A2B1000DE005 /* PasswordTextFieldViewPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E2CF3F26D2A2B1000DE005 /* PasswordTextFieldViewPageViewController.swift */; };
@@ -185,6 +189,10 @@
 		53C9F70326B5BC1A00EF7B86 /* YDSProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSProfileImageView.swift; sourceTree = "<group>"; };
 		53C9F70526B5BCCE00EF7B86 /* ProfileImageViewPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageViewPageViewController.swift; sourceTree = "<group>"; };
 		53C9F70B26B67CE900EF7B86 /* YDSCheckbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSCheckbox.swift; sourceTree = "<group>"; };
+		53E26E8526F0619E0036648E /* TypographiesPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographiesPageViewController.swift; sourceTree = "<group>"; };
+		53E26E8726F061F80036648E /* TypographiesListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographiesListTableViewController.swift; sourceTree = "<group>"; };
+		53E26E8926F062180036648E /* TypographiesListItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographiesListItemCell.swift; sourceTree = "<group>"; };
+		53E26E8B26F0637A0036648E /* YDSTypographyArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTypographyArray.swift; sourceTree = "<group>"; };
 		53E2CF3B26D29F62000DE005 /* SimpleTextFieldViewPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTextFieldViewPageViewController.swift; sourceTree = "<group>"; };
 		53E2CF3D26D2A1ED000DE005 /* SuffixTextFieldViewPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuffixTextFieldViewPageViewController.swift; sourceTree = "<group>"; };
 		53E2CF3F26D2A2B1000DE005 /* PasswordTextFieldViewPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordTextFieldViewPageViewController.swift; sourceTree = "<group>"; };
@@ -274,6 +282,7 @@
 			children = (
 				53C9F6FB26B5568600EF7B86 /* YDSIconArray.swift */,
 				532DBFDA26ED0508008C2354 /* YDSColorArray.swift */,
+				53E26E8B26F0637A0036648E /* YDSTypographyArray.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -401,6 +410,7 @@
 			isa = PBXGroup;
 			children = (
 				532DBFDD26ED0CEE008C2354 /* Color */,
+				53E26E8426F061720036648E /* Typography */,
 			);
 			path = FoundationSampleViewController;
 			sourceTree = "<group>";
@@ -436,6 +446,16 @@
 				53C9F6F826B5546400EF7B86 /* YDSButtonProtocol.swift */,
 			);
 			path = YDSButton;
+			sourceTree = "<group>";
+		};
+		53E26E8426F061720036648E /* Typography */ = {
+			isa = PBXGroup;
+			children = (
+				53E26E8526F0619E0036648E /* TypographiesPageViewController.swift */,
+				53E26E8726F061F80036648E /* TypographiesListTableViewController.swift */,
+				53E26E8926F062180036648E /* TypographiesListItemCell.swift */,
+			);
+			path = Typography;
 			sourceTree = "<group>";
 		};
 		53EFF5CC26BA9A7B00732DCF /* Component */ = {
@@ -721,6 +741,7 @@
 				532DBFD726EC736C008C2354 /* UIStackView+AddArrangedSubviews.swift in Sources */,
 				538ACCAE26EB40380044A437 /* ColorsPageViewController.swift in Sources */,
 				537FFAA426C3E5C200270C22 /* TopBarPageViewController.swift in Sources */,
+				53E26E8826F061F80036648E /* TypographiesListTableViewController.swift in Sources */,
 				53E2CF3C26D29F62000DE005 /* SimpleTextFieldViewPageViewController.swift in Sources */,
 				538ACCB226EB409C0044A437 /* ColorsListItemCell.swift in Sources */,
 				53E2CF4426D2A462000DE005 /* SearchBarPageViewController.swift in Sources */,
@@ -735,7 +756,9 @@
 				532DBFD526EC734F008C2354 /* UIView+AddSubviews.swift in Sources */,
 				537A0ACE26C4188C00142DCE /* DoubleTitleTopBarSampleViewController.swift in Sources */,
 				537FFAA626C3E6F800270C22 /* TopBarSampleViewController.swift in Sources */,
+				53E26E8626F0619E0036648E /* TypographiesPageViewController.swift in Sources */,
 				537A0AD026C4189700142DCE /* SingleTitleTopBarSampleViewController.swift in Sources */,
+				53E26E8A26F062180036648E /* TypographiesListItemCell.swift in Sources */,
 				53EFF5D426BBC26900732DCF /* ToastPageViewController.swift in Sources */,
 				533A27B926A5351E009FD90A /* PageListTableViewCell.swift in Sources */,
 				539110B426C049BD0094FD08 /* SingleTitleTopBarPageViewController.swift in Sources */,
@@ -753,6 +776,7 @@
 				53E2CF3E26D2A1ED000DE005 /* SuffixTextFieldViewPageViewController.swift in Sources */,
 				53441B0026AF233800CB6BC9 /* PickerControllerView.swift in Sources */,
 				5337938C26AF096A00BE5860 /* StorybookPageViewController.swift in Sources */,
+				53E26E8C26F0637A0036648E /* YDSTypographyArray.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -910,7 +910,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.yourssu.YDS-Storybook";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = GithubActions_Dist;
@@ -1109,7 +1109,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.yourssu.YDS-Storybook";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -1130,7 +1130,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.yourssu.YDS-Storybook";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/YDS/Source/Foundation/YDSTypoStyle.swift
+++ b/YDS/Source/Foundation/YDSTypoStyle.swift
@@ -29,71 +29,72 @@ extension String {
         case caption1
         case caption2
         
-        internal func style(color: UIColor? = nil) -> [NSAttributedString.Key: Any] {
-            let finalFont: UIFont
-            let finalLineHeight: CGFloat
-            let paragraphStyle = NSMutableParagraphStyle()
-            
-            let lineHeight100: CGFloat = 1.0
-            let lineHeight130: CGFloat = 1.3
-            let lineHeight160: CGFloat = 1.6
-    
+        public var font: UIFont {
             switch self {
             case .title1:
-                finalFont = YDSFont.title1
-                finalLineHeight = finalFont.pointSize * lineHeight130
+                return YDSFont.title1
             case .title2:
-                finalFont = YDSFont.title2
-                finalLineHeight = finalFont.pointSize * lineHeight130
+                return YDSFont.title2
             case .title3:
-                finalFont = YDSFont.title3
-                finalLineHeight = finalFont.pointSize * lineHeight130
-                
+                return YDSFont.title3
+            
+            
             case .subtitle1:
-                finalFont = YDSFont.subtitle1
-                finalLineHeight = finalFont.pointSize * lineHeight130
+                return YDSFont.subtitle1
             case .subtitle2:
-                finalFont = YDSFont.subtitle2
-                finalLineHeight = finalFont.pointSize * lineHeight130
+                return YDSFont.subtitle2
             case .subtitle3:
-                finalFont = YDSFont.subtitle3
-                finalLineHeight = finalFont.pointSize * lineHeight130
+                return YDSFont.subtitle3
                 
             case .body1:
-                finalFont = YDSFont.body1
-                finalLineHeight = finalFont.pointSize * lineHeight160
+                return YDSFont.body1
             case .body2:
-                finalFont = YDSFont.body2
-                finalLineHeight = finalFont.pointSize * lineHeight160
+                return YDSFont.body2
                 
             case .button0:
-                finalFont = YDSFont.button0
-                finalLineHeight = finalFont.pointSize * lineHeight100
+                return YDSFont.button0
             case .button1:
-                finalFont = YDSFont.button1
-                finalLineHeight = finalFont.pointSize * lineHeight100
+                return YDSFont.button1
             case .button2:
-                finalFont = YDSFont.button2
-                finalLineHeight = finalFont.pointSize * lineHeight100
+                return YDSFont.button2
             case .button3:
-                finalFont = YDSFont.button3
-                finalLineHeight = finalFont.pointSize * lineHeight100
+                return YDSFont.button3
             case .button4:
-                finalFont = YDSFont.button4
-                finalLineHeight = finalFont.pointSize * lineHeight100
+                return YDSFont.button4
                 
             case .caption1:
-                finalFont = YDSFont.caption1
-                finalLineHeight = finalFont.pointSize * lineHeight130
+                return YDSFont.caption1
             case .caption2:
-                finalFont = YDSFont.caption2
-                finalLineHeight = finalFont.pointSize * lineHeight130
+                return YDSFont.caption2
             }
+        }
         
-            paragraphStyle.lineSpacing = finalLineHeight - finalFont.lineHeight
+        public var lineHeight: CGFloat {
+            switch self {
+            case .title1, .title2, .title3:
+                return 1.3
+                
+            case .subtitle1, .subtitle2, .subtitle3:
+                return 1.3
+                
+            case .body1, .body2:
+                return 1.6
+                
+            case .button0, .button1, .button2, .button3, .button4:
+                return 1.0
+                
+            case .caption1, .caption2:
+                return 1.3
+            }
+        }
+        
+        internal func style(color: UIColor? = nil) -> [NSAttributedString.Key: Any] {
+            let paragraphStyle = NSMutableParagraphStyle()
+            
+            paragraphStyle.lineSpacing = self.lineHeight - self.font.lineHeight
             let attributes: [NSAttributedString.Key: Any] = [
                 .foregroundColor: color ?? UIColor.black,
-                .font: finalFont,
+                .font: self.font,
                 .paragraphStyle: paragraphStyle
             ]
             return attributes


### PR DESCRIPTION
## 📌 Summary
YDS의 TypoStyle 정의 방법을 변경했습니다.
YDS-Storybook에 Typography 페이지를 작성했습니다.

https://user-images.githubusercontent.com/54972653/133208630-141c60a1-e19d-465f-9d0e-6e715687b3a6.mov




## 💡 Reason
**TypoStyle** 
- font, lineHeight 값을 함수 외부에서 관리할 수 있도록 했습니다
- case 문을 중첩할 수 있어 관리가 편해집니다


## 📄 Description
**YDS/Source/Foundation/YDSTypoStyle.swift**
- font, lineHeight를 case문 외부로 꺼내 computed property로 관리하도록 했습니다

**YDS-Storybook/Resources/YDSTypographyArray.swift**
- YDS의 Typo 스타일을 담은 배열입니다

**YDS-Storybook/FoundationSampleViewController/Typography/TypographiesPageViewController.swift**
- Typography 페이지의 뷰 컨트롤러입니다

**YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListTableViewController.swift**
- Typography를 보여주는 테이블 뷰 컨트롤러입니다
 
**YDS-Storybook/FoundationSampleViewController/Typography/TypographiesListItemCell.swift**
- 각 셀입니다



## 📚 기타 
[[Feature/YDS-73] Storybook에 Color Page 추가](https://github.com/yourssu/YDS-iOS/pull/76)
위 PR과 구조가 거의 유사합니다