### PR TITLE
[#82] navigationbar appearance 도입

### DIFF
--- a/YDS/Source/Component/TopBar/YDSNavigationController.swift
+++ b/YDS/Source/Component/TopBar/YDSNavigationController.swift
@@ -64,32 +64,28 @@ public class YDSNavigationController: UINavigationController {
      각종 프로퍼티를 세팅합니다.
      */
     private func setProperties() {
-        setNavigationBarBackIndicator()
-        setNavigationBarProperties()
-    }
-    
-
-    /**
-     NavigationBar의 뒤로가기 아이콘 이미지를 설정합니다.
-     */
-    private func setNavigationBarBackIndicator() {
-        let barAppearance =
-            UINavigationBar.appearance(whenContainedInInstancesOf: [YDSNavigationController.self])
-        barAppearance.backIndicatorImage = YDSIcon.arrowLeftLine
-        barAppearance.backIndicatorTransitionMaskImage = YDSIcon.arrowLeftLine
+        setNavigationBarAppearance()
     }
     
     /**
-     NavigationBar의 프로퍼티를 설정합니다.
+     NavigationBar의 외관을 설정합니다.
      */
-    private func setNavigationBarProperties() {
-        navigationBar.tintColor = YDSColor.buttonNormal
-        navigationBar.isTranslucent = false
-        navigationBar.shadowImage = UIImage()
-        navigationBar.titleTextAttributes = [
+    private func setNavigationBarAppearance() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = YDSColor.bgElevated
+        appearance.titleTextAttributes = [
             NSAttributedString.Key.foregroundColor: YDSColor.textPrimary,
             NSAttributedString.Key.font: YDSFont.subtitle2,
         ]
+        appearance.setBackIndicatorImage(YDSIcon.arrowLeftLine,
+                                         transitionMaskImage: YDSIcon.arrowLeftLine)
+        appearance.shadowColor = nil
+        
+        navigationBar.tintColor = YDSColor.buttonNormal
+        navigationBar.standardAppearance = appearance
+        navigationBar.scrollEdgeAppearance = appearance
+        navigationBar.compactAppearance = appearance
     }
     
     /**


### PR DESCRIPTION
## 📌 Summary
iOS 15에서 navigationbar 애니메이션이 정상 작동하지 않는 문제를 수정했습니다


## 💡 Reason
iOS 13부터 도입된 [UINavigationBarAppearance](https://developer.apple.com/documentation/uikit/uinavigationbarappearance) 를 사용해야 iOS 15부터 화면 전환 애니메이션이 끊기지 않는 것으로 보입니다
이를 해결하기 위해 navigationBar 로 접근하던 속성 대부분을 변경했습니다



## ✍️ Description
- 이슈 티켓 : https://github.com/yourssu/YDS-iOS/issues/82
- 슬랙에 올린 영상 : https://yourssu.slack.com/archives/CM8DWU3KP/p1632471592262700


## 📚 Reference 
[WWDC 영상(앞에 10분만 보면 됨)](https://developer.apple.com/videos/play/wwdc2019/224)
[한국어 블로그](https://zeddios.tistory.com/860)
