### PR TITLE
[Feature/YDS-84] TopBarButton 아이콘, 글자 수정 가능하게 변경

### DIFF
--- a/YDS-Storybook/ComponentSampleViewController/TopBar/TopBarSampleViewController.swift
+++ b/YDS-Storybook/ComponentSampleViewController/TopBar/TopBarSampleViewController.swift
@@ -45,8 +45,6 @@ class TopBarSampleViewController: UIViewController {
     private func setProperties() {
         self.view.backgroundColor = YDSColor.bgNormal
         self.topBar.topItem?.title = topBarInfo?.title
-        editButton.setTitle("완료", for: .selected)
-        starButton.setImage(YDSIcon.starFilled, for: .selected)
     }
     
     private func setLayouts() {
@@ -82,8 +80,16 @@ class TopBarSampleViewController: UIViewController {
     @objc
     private func buttonTapAction(_ sender: UIButton) {
         switch(sender) {
-        case editButton, starButton:
-            sender.isSelected.toggle()
+        case editButton:
+            editButton.isSelected.toggle()
+            editButton.isSelected
+            ? editButton.setTitle("완료", for: .normal)
+            : editButton.setTitle("편집", for: .normal)
+        case starButton:
+            starButton.isSelected.toggle()
+            starButton.isSelected
+            ? starButton.setImage(YDSIcon.starFilled, for: .normal)
+            : starButton.setImage(YDSIcon.starLine, for: .normal)
         case dismissButton:
             self.dismiss(animated: true, completion: nil)
         default:

--- a/YDS-Storybook/ComponentSampleViewController/TopBar/TopBarSampleViewController.swift
+++ b/YDS-Storybook/ComponentSampleViewController/TopBar/TopBarSampleViewController.swift
@@ -12,8 +12,8 @@ import SnapKit
 class TopBarSampleViewController: UIViewController {
     
     private let topBar = YDSTopBar()
-    private let doneButton = YDSTopBarButton(text: "완료")
-    private let cancelButton = YDSTopBarButton(text: "취소")
+    private let editButton = YDSTopBarButton(text: "편집")
+    private let starButton = YDSTopBarButton(image: YDSIcon.starLine)
     
     private let dismissButton: YDSBoxButton = {
         let button = YDSBoxButton()
@@ -45,6 +45,8 @@ class TopBarSampleViewController: UIViewController {
     private func setProperties() {
         self.view.backgroundColor = YDSColor.bgNormal
         self.topBar.topItem?.title = topBarInfo?.title
+        editButton.setTitle("완료", for: .selected)
+        starButton.setImage(YDSIcon.starFilled, for: .selected)
     }
     
     private func setLayouts() {
@@ -55,8 +57,8 @@ class TopBarSampleViewController: UIViewController {
     private func setViewHierarchy() {
         self.view.addSubview(topBar)
         self.view.addSubview(dismissButton)
-        self.topBar.topItem?.setLeftBarButton(UIBarButtonItem(customView: cancelButton), animated: true)
-        self.topBar.topItem?.setRightBarButton(UIBarButtonItem(customView: doneButton), animated: true)
+        self.topBar.topItem?.setLeftBarButton(UIBarButtonItem(customView: starButton), animated: true)
+        self.topBar.topItem?.setRightBarButton(UIBarButtonItem(customView: editButton), animated: true)
     }
     
     private func setAutolayout() {
@@ -72,7 +74,7 @@ class TopBarSampleViewController: UIViewController {
     }
     
     private func registerTapAction() {
-        [dismissButton, doneButton, cancelButton].forEach {
+        [dismissButton, editButton, starButton].forEach {
             $0.addTarget(self, action: #selector(buttonTapAction(_:)), for: .touchUpInside)
         }
     }
@@ -80,7 +82,9 @@ class TopBarSampleViewController: UIViewController {
     @objc
     private func buttonTapAction(_ sender: UIButton) {
         switch(sender) {
-        case doneButton, cancelButton, dismissButton:
+        case editButton, starButton:
+            sender.isSelected.toggle()
+        case dismissButton:
             self.dismiss(animated: true, completion: nil)
         default:
             return

--- a/YDS/Source/Component/TopBar/YDSTopBarButton.swift
+++ b/YDS/Source/Component/TopBar/YDSTopBarButton.swift
@@ -81,6 +81,28 @@ public class YDSTopBarButton: UIButton {
     }
     
     /**
+     버튼의 Title을 설정합니다.
+     만약 이 버튼에 설정된 image가 있다면 이 메소드가 작동하지 않습니다.
+     
+     - Parameters:
+        - text: 버튼에 들어갈 글귀입니다.
+     */
+    public override func setTitle(_ title: String?,
+                                  for state: UIControl.State) {
+        if image(for: .normal) == nil
+            || image(for: .highlighted) == nil
+            || image(for: .disabled) == nil
+            || image(for: .selected) == nil
+            || image(for: .focused) == nil
+            || image(for: .application) == nil
+            || image(for: .reserved) == nil {
+            return
+        }
+        
+        super.setTitle(title, for: state)
+    }
+    
+    /**
      이미지만 들어가는 버튼을 생성합니다. 이 버튼은 TopBar에만 사용하길 권장합니다.
      
      - Parameters:
@@ -93,6 +115,29 @@ public class YDSTopBarButton: UIButton {
                         .withRenderingMode(.alwaysTemplate),
                       for: .normal)
         setupView()
+    }
+    
+    /**
+     버튼의 Image를 설정합니다.
+     만약 이 버튼에 설정된 Title이 있다면 이 메소드가 작동하지 않습니다.
+     
+     - Parameters:
+        - image: 버튼에 들어갈 이미지입니다.
+     */
+    public override func setImage(_ image: UIImage?,
+                                  for state: UIControl.State) {
+        if title(for: .normal) == nil
+            || title(for: .highlighted) == nil
+            || title(for: .disabled) == nil
+            || title(for: .selected) == nil
+            || title(for: .highlighted) == nil
+            || title(for: .focused) == nil
+            || title(for: .application) == nil
+            || title(for: .reserved) == nil {
+            return
+        }
+        
+        super.setImage(image, for: state)
     }
     
     required init?(coder: NSCoder) {

--- a/YDS/Source/Component/TopBar/YDSTopBarButton.swift
+++ b/YDS/Source/Component/TopBar/YDSTopBarButton.swift
@@ -89,13 +89,13 @@ public class YDSTopBarButton: UIButton {
      */
     public override func setTitle(_ title: String?,
                                   for state: UIControl.State) {
-        if image(for: .normal) == nil
-            || image(for: .highlighted) == nil
-            || image(for: .disabled) == nil
-            || image(for: .selected) == nil
-            || image(for: .focused) == nil
-            || image(for: .application) == nil
-            || image(for: .reserved) == nil {
+        if image(for: .normal) != nil
+            || image(for: .highlighted) != nil
+            || image(for: .disabled) != nil
+            || image(for: .selected) != nil
+            || image(for: .focused) != nil
+            || image(for: .application) != nil
+            || image(for: .reserved) != nil {
             return
         }
         
@@ -126,14 +126,14 @@ public class YDSTopBarButton: UIButton {
      */
     public override func setImage(_ image: UIImage?,
                                   for state: UIControl.State) {
-        if title(for: .normal) == nil
-            || title(for: .highlighted) == nil
-            || title(for: .disabled) == nil
-            || title(for: .selected) == nil
-            || title(for: .highlighted) == nil
-            || title(for: .focused) == nil
-            || title(for: .application) == nil
-            || title(for: .reserved) == nil {
+        if title(for: .normal) != nil
+            || title(for: .highlighted) != nil
+            || title(for: .disabled) != nil
+            || title(for: .selected) != nil
+            || title(for: .highlighted) != nil
+            || title(for: .focused) != nil
+            || title(for: .application) != nil
+            || title(for: .reserved) != nil {
             return
         }
         

--- a/YDS/Source/Component/TopBar/YDSTopBarButton.swift
+++ b/YDS/Source/Component/TopBar/YDSTopBarButton.swift
@@ -35,6 +35,7 @@ public class YDSTopBarButton: UIButton {
         didSet {
             if oldValue != isHighlighted {
                 setTintColorBasedOnIsHighlighted()
+                setTitleColorBasedOnIsHighlighted()
             }
         }
     }
@@ -137,7 +138,10 @@ public class YDSTopBarButton: UIButton {
             return
         }
         
-        super.setImage(image, for: state)
+        super.setImage(image?
+                        .resize(to: Dimension.content.imageSize)
+                        .withRenderingMode(.alwaysTemplate),
+                       for: state)
     }
     
     required init?(coder: NSCoder) {
@@ -178,14 +182,20 @@ public class YDSTopBarButton: UIButton {
             fgPressedColor = YDSColor.buttonNormalPressed
         }
         
-        setTitleColor(fgColor, for: .normal)
-        setTitleColor(fgPressedColor, for: .highlighted)
-        
+        setTitleColorBasedOnIsHighlighted()
         setTintColorBasedOnIsHighlighted()
     }
     
     /**
-     setTintColorBasedOnIsHighlighted()
+     isHighlighted 값에 맞추어 titleColor를 변경합니다.
+     */
+    private func setTitleColorBasedOnIsHighlighted() {
+        !isHighlighted
+        ? setTitleColor(fgColor, for: .normal)
+        : setTitleColor(fgPressedColor, for: .normal)
+    }
+    
+    /**
      isHighlighted 값에 맞추어 tintColor를 변경합니다.
      */
     private func setTintColorBasedOnIsHighlighted() {


### PR DESCRIPTION
## 📌 Summary
<img width="1018" alt="스크린샷 2021-11-21 오후 2 09 14" src="https://user-images.githubusercontent.com/54972653/142750409-236391f5-a97d-4722-a8c1-e7dbe430ffad.png">

1. TopBarButton의 setTitle, setImage 함수를 오버라이딩 하여 이미지 속 밑줄 친 조건을 충족시켰습니다 

2. setTitle, setImage 함수로 버튼의 내용물을 바꿨을 때 pressed 컬러가 제대로 적용되도록 수정했습니다


## 💡 Reason
1. 
setTitle과 setImage 함수를 오버라이딩 하기 전에는
TopBarButton에 이미지와 텍스트가 동시에 존재할 수가 있었습니다

이를 방지하기 위해 setTitle 함수가 작동될 때 Image가 있는지 없는지 미리 파악한 후
Image가 없을 경우에만 작동하도록 수정했습니다

setImage 함수 역시 마찬가지입니다

2.
UIControl.State는 normal, highlighted, disabled, selected, focused, application, reserved 등의 상태를 가지고 있는데
이들 상태는 배타적이지 않고 중복될 수 있습니다

이에 따라 selected이면서 highlighted인 상태가 발생하기도 하는데
이 경우엔 setTitleColor(fgPressedColor, for: .highlighted) 이런 식으로 컬러를 지정해주더라도 
`highlighted 상태`와 `highlighted 이면서 selected인 상태`는 서로 다른 상태이기 때문에 pressed 컬러가 제대로 지정되지 않습니다

이 문제를 해결하기 위해 TopBarButton 내부에서 isHighlighted 값에 따라서 titleColor를 지정하도록 코드를 수정했습니다

저도 뭐라고 설명해야 할지 이게 좀 난감하네요...

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : https://github.com/yourssu/YDS-iOS/issues/84
- 스펙 문서 : https://www.notion.so/yourssu/TopBar-TopBarButton-01890f9538254b72ac44c189eacbb2fa



## 📄 More File Description
- YDS/Source/Component/TopBar/YDSTopBarButton.swift
수정한 TopBarButton 파일입니다.

- YDS-Storybook/ComponentSampleViewController/TopBar/TopBarSampleViewController.swift
버튼의 내용물이 바뀌도록 테스트 페이지 하나를 수정했습니다.

https://user-images.githubusercontent.com/54972653/142755097-ea3cca9d-a631-4085-bb2d-c4d80b0eec0f.mp4



