### PR TITLE
[Feature/YDS-83] YDSLabel 속성 대응 다양화 & 샘플 페이지 작성

### DIFF
--- a/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
+++ b/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
@@ -26,7 +26,6 @@ class LabelPageViewController: StoryBookViewController {
     
     private func setViewProperty() {
         title = "Label"
-        sampleLabel.numberOfLines = 0
     }
     
     private func setViewLayouts() {

--- a/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
+++ b/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
@@ -1,0 +1,113 @@
+//
+//  LabelPageViewController.swift
+//  YDS-Storybook
+//
+//  Created by Gyuni on 2021/11/21.
+//
+
+import SnapKit
+import UIKit
+import YDS
+
+class LabelPageViewController: StoryBookViewController {
+    
+    private let sampleLabel = YDSLabel()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+        addOptions()
+    }
+    
+    private func setupView() {
+        setViewProperty()
+        setViewLayouts()
+    }
+    
+    private func setViewProperty() {
+        title = "Label"
+        sampleLabel.numberOfLines = 0
+    }
+    
+    private func setViewLayouts() {
+        setViewHierarchy()
+        setAutolayout()
+    }
+    
+    private func setViewHierarchy() {
+        sampleView.addSubviews(sampleLabel)
+    }
+    
+    private func setAutolayout() {
+        sampleLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.lessThanOrEqualToSuperview().inset(16)
+            $0.height.lessThanOrEqualToSuperview().inset(16)
+        }
+    }
+    
+    private func addOptions() {
+        addOption(description: "text",
+                  defaultValue: "Label") { [weak self] value in
+            self?.sampleLabel.text = value
+        }
+        
+        addOption(description: "style",
+                  cases: String.TypoStyle.allCases,
+                  defaultIndex: 0) { [weak self] value in
+            self?.sampleLabel.style = value
+        }
+        
+        addOption(description: "numberOfLines",
+                  defaultValue: 0) { [weak self] value in
+            self?.sampleLabel.numberOfLines = value
+        }
+        
+        addOption(description: "textColor",
+                  cases: textColors.items.map { $0.color },
+                  defaultIndex: 0) { [weak self] value in
+            self?.sampleLabel.textColor = value
+        }
+        
+        addOption(description: "lineBreakMode",
+                  cases: NSLineBreakMode.allCases,
+                  defaultIndex: 0) { [weak self] value in
+            self?.sampleLabel.lineBreakMode = value
+        }
+        
+        if #available(iOS 14.0, *) {
+            addOption(description: "lineBreakStrategy",
+                      cases: NSParagraphStyle.LineBreakStrategy.allCases,
+                      defaultIndex: 1) { [weak self] value in
+                self?.sampleLabel.lineBreakStrategy = value
+            }
+        }
+    }
+    
+}
+
+extension String.TypoStyle: CaseIterable {
+    public static var allCases: [String.TypoStyle] = [.title1, .title2, .title3,
+                                                      .subtitle1, .subtitle2, .subtitle3,
+                                                      .body1, .body2,
+                                                      .button0, .button1, .button2, .button3, .button4,
+                                                      .caption0, .caption1, .caption2]
+}
+
+extension NSLineBreakMode: CaseIterable {
+    public static var allCases: [NSLineBreakMode] = [.byWordWrapping,
+                                                     .byCharWrapping,
+                                                     .byClipping,
+                                                     .byTruncatingHead,
+                                                     .byTruncatingMiddle,
+                                                     .byTruncatingTail,]
+}
+
+@available(iOS 14.0, *)
+extension NSParagraphStyle.LineBreakStrategy: CaseIterable {
+    public static var allCases: [NSParagraphStyle.LineBreakStrategy] = [.pushOut,
+                                                                        .hangulWordPriority,
+                                                                        .standard,]
+}
+
+

--- a/YDS-Storybook/PageListViewController.swift
+++ b/YDS-Storybook/PageListViewController.swift
@@ -35,6 +35,7 @@ class PageListViewController: UIViewController {
     ]
     
     let atomPages: [Page] = [
+        Page(title: "Label", vc: LabelPageViewController.self),
         Page(title: "ProfileImageView", vc: ProfileImageViewPageViewController.self),
         Page(title: "Badge", vc: BadgePageViewController.self),
         Page(title: "BoxButton", vc: BoxButtonPageViewController.self),

--- a/YDS-Storybook/Storybook/ControllerView/IntControllerView.swift
+++ b/YDS-Storybook/Storybook/ControllerView/IntControllerView.swift
@@ -1,0 +1,47 @@
+//
+//  IntControllerView.swift
+//  YDS-Storybook
+//
+//  Created by Gyuni on 2021/11/21.
+//
+
+import UIKit
+
+final class IntControllerView: ControllerView<Int> {
+
+    public override init() {
+        super.init()
+        
+        textFieldView.textField.addTarget(
+            self,
+            action: #selector(textFieldDidChange(_:)),
+            for: .editingChanged
+        )
+        
+        textFieldView.textField.keyboardType = .numberPad
+        
+        setInitialState()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setInitialState() {
+        observable
+            .take(1)
+            .subscribe(onNext: { value in
+                self.textFieldView.text = String(describing: value)
+            })
+            .disposed(by: bag)
+    }
+    
+    @objc
+    func textFieldDidChange(_ textField: UITextField) {
+        if let text = textField.text,
+           let number = Int(text) {
+            observable.onNext(number)
+        }
+    }
+    
+}

--- a/YDS-Storybook/Storybook/StorybookPageViewController.swift
+++ b/YDS-Storybook/Storybook/StorybookPageViewController.swift
@@ -125,6 +125,17 @@ class StoryBookViewController: UIViewController {
     
     //  MARK: - 옵션 추가를 위한 함수
     
+    //  Int
+    public func addOption(description: String?, defaultValue: Int,  task: @escaping (Int) -> Void) {
+        let controllerView: IntControllerView = {
+            let controllerView = IntControllerView()
+            controllerView.parameterLabel.text = description
+            return controllerView
+        }()
+        
+        setControllerView(controllerView, defaultValue: defaultValue, task: task)
+    }
+    
     //  Optional String
     public func addOption(description: String?, defaultValue: String?,  task: @escaping (String?) -> Void) {
         let controllerView: OptionalStringControllerView = {

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		5359A5C126BEC99700FCCECC /* BottomBarControllerPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5359A5C026BEC99700FCCECC /* BottomBarControllerPageViewController.swift */; };
 		5359A5C326BECF7400FCCECC /* YDSDoubleTitleTopBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5359A5C226BECF7400FCCECC /* YDSDoubleTitleTopBar.swift */; };
 		5359A5C526BED19900FCCECC /* DoubleTitleTopBarPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5359A5C426BED19900FCCECC /* DoubleTitleTopBarPageViewController.swift */; };
+		5365FD59274A41F400B6FBF9 /* LabelPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5365FD58274A41F400B6FBF9 /* LabelPageViewController.swift */; };
+		5365FD5B274A4ED000B6FBF9 /* IntControllerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5365FD5A274A4ED000B6FBF9 /* IntControllerView.swift */; };
 		536FCA50267CD25300158DFD /* YDSIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 536FCA4F267CD25300158DFD /* YDSIcon.xcassets */; };
 		5370918226A5463C007CD775 /* YDSSuffixTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5370918126A5463C007CD775 /* YDSSuffixTextField.swift */; };
 		5370918426A5467D007CD775 /* YDSSuffixTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5370918326A5467D007CD775 /* YDSSuffixTextFieldView.swift */; };
@@ -158,6 +160,8 @@
 		5359A5C026BEC99700FCCECC /* BottomBarControllerPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomBarControllerPageViewController.swift; sourceTree = "<group>"; };
 		5359A5C226BECF7400FCCECC /* YDSDoubleTitleTopBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSDoubleTitleTopBar.swift; sourceTree = "<group>"; };
 		5359A5C426BED19900FCCECC /* DoubleTitleTopBarPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTitleTopBarPageViewController.swift; sourceTree = "<group>"; };
+		5365FD58274A41F400B6FBF9 /* LabelPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelPageViewController.swift; sourceTree = "<group>"; };
+		5365FD5A274A4ED000B6FBF9 /* IntControllerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntControllerView.swift; sourceTree = "<group>"; };
 		536FCA4F267CD25300158DFD /* YDSIcon.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = YDSIcon.xcassets; sourceTree = "<group>"; };
 		5370918126A5463C007CD775 /* YDSSuffixTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSSuffixTextField.swift; sourceTree = "<group>"; };
 		5370918326A5467D007CD775 /* YDSSuffixTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSSuffixTextFieldView.swift; sourceTree = "<group>"; };
@@ -321,6 +325,7 @@
 				53441B0626AF2B4800CB6BC9 /* Base */,
 				53441B0326AF287600CB6BC9 /* BoolControllerView.swift */,
 				53441B0126AF248900CB6BC9 /* EnumControllerView.swift */,
+				5365FD5A274A4ED000B6FBF9 /* IntControllerView.swift */,
 				5337938F26AF0A0600BE5860 /* OptionalStringControllerView.swift */,
 				53441AFD26AF1E7E00CB6BC9 /* OptionalImageControllerView.swift */,
 			);
@@ -379,6 +384,7 @@
 		53443D9C26A7D3CC0037B02E /* AtomSampleViewController */ = {
 			isa = PBXGroup;
 			children = (
+				5365FD58274A41F400B6FBF9 /* LabelPageViewController.swift */,
 				53C445B026B92BEB00AAC753 /* CheckboxPageViewController.swift */,
 				53C9F70526B5BCCE00EF7B86 /* ProfileImageViewPageViewController.swift */,
 				5337939126AF0A7300BE5860 /* BoxButtonPageViewController.swift */,
@@ -743,6 +749,7 @@
 				537FFAA426C3E5C200270C22 /* TopBarPageViewController.swift in Sources */,
 				53E26E8826F061F80036648E /* TypographiesListTableViewController.swift in Sources */,
 				53E2CF3C26D29F62000DE005 /* SimpleTextFieldViewPageViewController.swift in Sources */,
+				5365FD5B274A4ED000B6FBF9 /* IntControllerView.swift in Sources */,
 				538ACCB226EB409C0044A437 /* ColorsListItemCell.swift in Sources */,
 				53E2CF4426D2A462000DE005 /* SearchBarPageViewController.swift in Sources */,
 				53C9F6FC26B5568600EF7B86 /* YDSIconArray.swift in Sources */,
@@ -776,6 +783,7 @@
 				53E2CF3E26D2A1ED000DE005 /* SuffixTextFieldViewPageViewController.swift in Sources */,
 				53441B0026AF233800CB6BC9 /* PickerControllerView.swift in Sources */,
 				5337938C26AF096A00BE5860 /* StorybookPageViewController.swift in Sources */,
+				5365FD59274A41F400B6FBF9 /* LabelPageViewController.swift in Sources */,
 				53E26E8C26F0637A0036648E /* YDSTypographyArray.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/YDS/Source/Atom/YDSLabel.swift
+++ b/YDS/Source/Atom/YDSLabel.swift
@@ -12,15 +12,6 @@ public class YDSLabel: UILabel {
         didSet { setAttributedText() }
     }
     
-    public init(style: String.TypoStyle) {
-        self.style = style
-        super.init(frame: CGRect.zero)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
     public override var text: String? {
         didSet { setAttributedText() }
     }
@@ -29,14 +20,33 @@ public class YDSLabel: UILabel {
         didSet { setAttributedText() }
     }
     
-    private func setAttributedText() {
-        if let text = self.text {
-            if let color = textColor {
-                self.attributedText = text.attributedString(byPreset: style, color: color)
-            } else {
-                self.attributedText = text.attributedString(byPreset: style)
-            }
+    public override var lineBreakMode: NSLineBreakMode {
+        didSet { setAttributedText() }
+    }
+    
+    public override var lineBreakStrategy: NSParagraphStyle.LineBreakStrategy {
+        didSet { setAttributedText() }
+    }
+    
+    public init(style: String.TypoStyle = .body1) {
+        self.style = style
+        super.init(frame: CGRect.zero)
+        
+        if #available(iOS 14.0, *) {
+            self.lineBreakStrategy = .hangulWordPriority
         }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setAttributedText() { 
+        guard let text = self.text else { return }
+        attributedText = text.attributedString(byPreset: style,
+                                               color: textColor,
+                                               lineBreakMode: lineBreakMode,
+                                               lineBreakStrategy: lineBreakStrategy)
     }
 }
 

--- a/YDS/Source/Foundation/YDSTypoStyle.swift
+++ b/YDS/Source/Foundation/YDSTypoStyle.swift
@@ -91,10 +91,18 @@ extension String {
             }
         }
         
-        internal func style(color: UIColor? = nil) -> [NSAttributedString.Key: Any] {
+        internal func style(color: UIColor? = nil,
+                            lineBreakMode: NSLineBreakMode? = nil,
+                            lineBreakStrategy: NSParagraphStyle.LineBreakStrategy? = nil) -> [NSAttributedString.Key: Any] {
             let paragraphStyle = NSMutableParagraphStyle()
             
             paragraphStyle.lineSpacing = self.font.pointSize*self.lineHeight - self.font.lineHeight
+            if let lineBreakMode = lineBreakMode {
+                paragraphStyle.lineBreakMode = lineBreakMode
+            }
+            if let lineBreakStrategy = lineBreakStrategy {
+                paragraphStyle.lineBreakStrategy = lineBreakStrategy
+            }
             let attributes: [NSAttributedString.Key: Any] = [
                 .foregroundColor: color ?? UIColor.black,
                 .font: self.font,
@@ -105,8 +113,14 @@ extension String {
         
     }
     
-    internal func attributedString(byPreset preset: TypoStyle, color: UIColor? = nil) -> NSAttributedString {
-        return NSAttributedString.init(string : self, attributes: preset.style(color: color))
+    internal func attributedString(byPreset preset: TypoStyle,
+                                   color: UIColor? = nil,
+                                   lineBreakMode: NSLineBreakMode? = nil,
+                                   lineBreakStrategy: NSParagraphStyle.LineBreakStrategy? = nil) -> NSAttributedString {
+        return NSAttributedString.init(string : self,
+                                       attributes: preset.style(color: color,
+                                                                lineBreakMode: lineBreakMode,
+                                                                lineBreakStrategy: lineBreakStrategy))
     }
 
 }


### PR DESCRIPTION
## 📌 Summary

<img width="903" alt="스크린샷 2021-11-21 오후 7 53 57" src="https://user-images.githubusercontent.com/54972653/142758958-a232f86f-15ba-4e38-9ee6-0225cc2c1521.png">
YDSLabel이 lineBreakMode, lineBreakStrategy에 대응하도록 수정했습니다
Storybook에 YDSLabel 페이지를 추가했습니다


## 💡 Reason
기존엔 lineBreakMode, lineBreakStrategy에 대응을 하지 않아서 외부에서 수정하려 해도 수정되지 않던 문제가 있었습니다.
이에 대응했습니다.

또한 Storybook에 YDSLabel을 사용해볼 수 있는 페이지도 추가했습니다.


## ✍️ Description
- 이슈 티켓 : https://github.com/yourssu/YDS-iOS/issues/83


https://user-images.githubusercontent.com/54972653/142758728-b053f96e-928a-4668-9c6c-7c25e3e99138.mp4

https://user-images.githubusercontent.com/54972653/142758741-cc6aa6b3-2c26-4244-9aec-765fb83b4539.mp4

https://user-images.githubusercontent.com/54972653/142758755-76e74413-ede3-4e55-acc6-577a4f306d93.mp4





## 📄 More File Description
**- YDS/Source/Atom/YDSLabel.swift**
lineBreakMode, lineBreakStrategy에 대응하도록 수정했습니다
그 외 겸사겸사 생성자에 style의 기본 값을 설정했습니다 (이게 없어서 은근 쓰다보니까 불편하더라고요)

**- YDS/Source/Foundation/YDSTypoStyle.swift**
lineBreakMode, lineBreakStrategy에 대응하도록 수정했습니다

**- YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift**
YDSLabel을 테스트 해볼 수 있는 페이지입니다

**- YDS-Storybook/Storybook/ControllerView/IntControllerView.swift**
**- YDS-Storybook/Storybook/StorybookPageViewController.swift**
![Simulator Screen Shot - iPhone 12 Pro - 2021-11-21 at 19 37 57](https://user-images.githubusercontent.com/54972653/142758577-1a876925-a466-4ea4-a4f3-0fec03da3e22.png)
Int값을 입력할 수 있는 컨트롤러 뷰가 필요해서 만들었습니다

