### PR TITLE
[#114] 다크모드 컬러 업데이트 (Item 제외)

### DIFF
--- a/YDS-Storybook/AppDelegate.swift
+++ b/YDS-Storybook/AppDelegate.swift
@@ -20,7 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         window?.rootViewController = navigationController
         
-        window?.overrideUserInterfaceStyle = .light
         window?.makeKeyAndVisible()
         
         return true

--- a/YDS-Storybook/Resources/YDSColorArray.swift
+++ b/YDS-Storybook/Resources/YDSColorArray.swift
@@ -38,7 +38,7 @@ let textColors = Colors(
         Color(color: YDSColor.textSecondary, name: "textSecondary", basicColorName: "gray900"),
         Color(color: YDSColor.textTertiary, name: "textTertiary", basicColorName: "gray600"),
         Color(color: YDSColor.textDisabled, name: "textDisabled", basicColorName: "gray500"),
-        Color(color: YDSColor.textReversed, name: "textReversed", basicColorName: "white000"),
+        Color(color: YDSColor.textBright, name: "textBright", basicColorName: "white000"),
         Color(color: YDSColor.textPointed, name: "textPointed", basicColorName: "pointColor400"),
         Color(color: YDSColor.textWarned, name: "textWarned", basicColorName: "warningRed400"),
     ],
@@ -49,7 +49,7 @@ let dimColors = Colors(
     items: [
         Color(color: YDSColor.dimNormal, name: "dimNormal", basicColorName: "gray900A30"),
         Color(color: YDSColor.dimThick, name: "dimThick", basicColorName: "gray900A70"),
-        Color(color: YDSColor.dimThickReversed, name: "dimThickReversed", basicColorName: "white000A70"),
+        Color(color: YDSColor.dimThickBright, name: "dimThickBright", basicColorName: "white000A70"),
     ],
     description: "Dim"
 )
@@ -69,7 +69,7 @@ let buttonColors = Colors(
         Color(color: YDSColor.buttonNormalPressed, name: "buttonNormalPressed", basicColorName: "gray600"),
         Color(color: YDSColor.buttonBG, name: "buttonBG", basicColorName: "gray200"),
         Color(color: YDSColor.buttonEmojiBG, name: "buttonEmojiBG", basicColorName: "gray100"),
-        Color(color: YDSColor.buttonReversed, name: "buttonReversed", basicColorName: "white000"),
+        Color(color: YDSColor.buttonBright, name: "buttonBright", basicColorName: "white000"),
         Color(color: YDSColor.buttonDisabled, name: "buttonDisabled", basicColorName: "gray500"),
         Color(color: YDSColor.buttonDisabledBG, name: "buttonDisabledBG", basicColorName: "gray200"),
         Color(color: YDSColor.buttonPoint, name: "buttonPoint", basicColorName: "pointColor400"),

--- a/YDS-Storybook/Resources/YDSColorArray.swift
+++ b/YDS-Storybook/Resources/YDSColorArray.swift
@@ -26,7 +26,7 @@ let backgroundColors = Colors(
         Color(color: YDSColor.bgRecomment, name: "bgRecomment", basicColorName: "gray050 / realBlack"),
         Color(color: YDSColor.bgSelected, name: "bgSelected", basicColorName: "gray100 / gray900"),
         Color(color: YDSColor.bgPressed, name: "bgPressed", basicColorName: "gray100 / gray800"),
-        Color(color: YDSColor.bgNormalReversed, name: "bgNormalReversed", basicColorName: "realBlack / realBlack"),
+        Color(color: YDSColor.bgNormalDark, name: "bgNormalDark", basicColorName: "realBlack / realBlack"),
         Color(color: YDSColor.bgElevatedReversed, name: "bgElevatedReversed", basicColorName: "realBlack / realBlack"),
     ],
     description: "Background"

--- a/YDS-Storybook/Resources/YDSColorArray.swift
+++ b/YDS-Storybook/Resources/YDSColorArray.swift
@@ -27,7 +27,7 @@ let backgroundColors = Colors(
         Color(color: YDSColor.bgSelected, name: "bgSelected", basicColorName: "gray100 / gray900"),
         Color(color: YDSColor.bgPressed, name: "bgPressed", basicColorName: "gray100 / gray800"),
         Color(color: YDSColor.bgNormalDark, name: "bgNormalDark", basicColorName: "realBlack / realBlack"),
-        Color(color: YDSColor.bgElevatedReversed, name: "bgElevatedReversed", basicColorName: "realBlack / realBlack"),
+        Color(color: YDSColor.bgElevatedDark, name: "bgElevatedDark", basicColorName: "realBlack / realBlack"),
     ],
     description: "Background"
 )

--- a/YDS-Storybook/Resources/YDSColorArray.swift
+++ b/YDS-Storybook/Resources/YDSColorArray.swift
@@ -21,79 +21,79 @@ struct Colors {
 
 let backgroundColors = Colors(
     items: [
-        Color(color: YDSColor.bgNormal, name: "bgNormal", basicColorName: "white000"),
-        Color(color: YDSColor.bgElevated, name: "bgElevated", basicColorName: "white000"),
-        Color(color: YDSColor.bgRecomment, name: "bgRecomment", basicColorName: "gray050"),
-        Color(color: YDSColor.bgSelected, name: "bgSelected", basicColorName: "gray100"),
-        Color(color: YDSColor.bgPressed, name: "bgPressed", basicColorName: "gray100"),
-        Color(color: YDSColor.bgNormalReversed, name: "bgNormalReversed", basicColorName: "realBlack"),
-        Color(color: YDSColor.bgElevatedReversed, name: "bgElevatedReversed", basicColorName: "realBlack"),
+        Color(color: YDSColor.bgNormal, name: "bgNormal", basicColorName: "white000 / black000"),
+        Color(color: YDSColor.bgElevated, name: "bgElevated", basicColorName: "white000 / black000"),
+        Color(color: YDSColor.bgRecomment, name: "bgRecomment", basicColorName: "gray050 / realBlack"),
+        Color(color: YDSColor.bgSelected, name: "bgSelected", basicColorName: "gray100 / gray900"),
+        Color(color: YDSColor.bgPressed, name: "bgPressed", basicColorName: "gray100 / gray800"),
+        Color(color: YDSColor.bgNormalReversed, name: "bgNormalReversed", basicColorName: "realBlack / realBlack"),
+        Color(color: YDSColor.bgElevatedReversed, name: "bgElevatedReversed", basicColorName: "realBlack / realBlack"),
     ],
     description: "Background"
 )
 
 let textColors = Colors(
     items: [
-        Color(color: YDSColor.textPrimary, name: "textPrimary", basicColorName: "black000"),
-        Color(color: YDSColor.textSecondary, name: "textSecondary", basicColorName: "gray900"),
-        Color(color: YDSColor.textTertiary, name: "textTertiary", basicColorName: "gray600"),
-        Color(color: YDSColor.textDisabled, name: "textDisabled", basicColorName: "gray500"),
-        Color(color: YDSColor.textBright, name: "textBright", basicColorName: "white000"),
-        Color(color: YDSColor.textPointed, name: "textPointed", basicColorName: "pointColor400"),
-        Color(color: YDSColor.textWarned, name: "textWarned", basicColorName: "warningRed400"),
+        Color(color: YDSColor.textPrimary, name: "textPrimary", basicColorName: "black000 / gray100"),
+        Color(color: YDSColor.textSecondary, name: "textSecondary", basicColorName: "gray900 / gray200"),
+        Color(color: YDSColor.textTertiary, name: "textTertiary", basicColorName: "gray600 / gray600"),
+        Color(color: YDSColor.textDisabled, name: "textDisabled", basicColorName: "gray500/ gray700"),
+        Color(color: YDSColor.textBright, name: "textBright", basicColorName: "white000 / white000"),
+        Color(color: YDSColor.textPointed, name: "textPointed", basicColorName: "pointColor400 / pointColor300"),
+        Color(color: YDSColor.textWarned, name: "textWarned", basicColorName: "warningRed400 / warningRed300"),
     ],
     description: "Text"
 )
 
 let dimColors = Colors(
     items: [
-        Color(color: YDSColor.dimNormal, name: "dimNormal", basicColorName: "gray900A30"),
-        Color(color: YDSColor.dimThick, name: "dimThick", basicColorName: "gray900A70"),
-        Color(color: YDSColor.dimThickBright, name: "dimThickBright", basicColorName: "white000A70"),
+        Color(color: YDSColor.dimNormal, name: "dimNormal", basicColorName: "gray900A30 / gray900A30"),
+        Color(color: YDSColor.dimThick, name: "dimThick", basicColorName: "gray900A70 / gray900A70"),
+        Color(color: YDSColor.dimThickBright, name: "dimThickBright", basicColorName: "white000A70 / white000A70"),
     ],
     description: "Dim"
 )
 
 let borderColors = Colors(
     items: [
-        Color(color: YDSColor.borderThin, name: "borderThin", basicColorName: "gray100"),
-        Color(color: YDSColor.borderNormal, name: "borderNormal", basicColorName: "black000A10"),
-        Color(color: YDSColor.borderThick, name: "borderThick", basicColorName: "gray500"),
+        Color(color: YDSColor.borderThin, name: "borderThin", basicColorName: "gray100 / gray900"),
+        Color(color: YDSColor.borderNormal, name: "borderNormal", basicColorName: "black000A10 / white000A10"),
+        Color(color: YDSColor.borderThick, name: "borderThick", basicColorName: "gray500 / gray500"),
     ],
     description: "Border"
 )
 
 let buttonColors = Colors(
     items: [
-        Color(color: YDSColor.buttonNormal, name: "buttonNormal", basicColorName: "gray700"),
-        Color(color: YDSColor.buttonNormalPressed, name: "buttonNormalPressed", basicColorName: "gray600"),
-        Color(color: YDSColor.buttonBG, name: "buttonBG", basicColorName: "gray200"),
-        Color(color: YDSColor.buttonEmojiBG, name: "buttonEmojiBG", basicColorName: "gray100"),
-        Color(color: YDSColor.buttonBright, name: "buttonBright", basicColorName: "white000"),
-        Color(color: YDSColor.buttonDisabled, name: "buttonDisabled", basicColorName: "gray500"),
-        Color(color: YDSColor.buttonDisabledBG, name: "buttonDisabledBG", basicColorName: "gray200"),
-        Color(color: YDSColor.buttonPoint, name: "buttonPoint", basicColorName: "pointColor400"),
-        Color(color: YDSColor.buttonPointPressed, name: "buttonPointPressed", basicColorName: "pointColor300"),
-        Color(color: YDSColor.buttonPointBG, name: "buttonPointBG", basicColorName: "pointColor050"),
-        Color(color: YDSColor.buttonWarned, name: "buttonWarned", basicColorName: "warningRed400"),
-        Color(color: YDSColor.buttonWarnedPressed, name: "buttonWarnedPressed", basicColorName: "warningRed300"),
-        Color(color: YDSColor.buttonWarnedBG, name: "buttonWarnedBG", basicColorName: "warningRed050"),
+        Color(color: YDSColor.buttonNormal, name: "buttonNormal", basicColorName: "gray700 / gray300"),
+        Color(color: YDSColor.buttonNormalPressed, name: "buttonNormalPressed", basicColorName: "gray600 / gray200"),
+        Color(color: YDSColor.buttonBG, name: "buttonBG", basicColorName: "gray200 / gray800"),
+        Color(color: YDSColor.buttonEmojiBG, name: "buttonEmojiBG", basicColorName: "gray100 / gray900"),
+        Color(color: YDSColor.buttonBright, name: "buttonBright", basicColorName: "white000 / white000"),
+        Color(color: YDSColor.buttonDisabled, name: "buttonDisabled", basicColorName: "gray500 / gray600"),
+        Color(color: YDSColor.buttonDisabledBG, name: "buttonDisabledBG", basicColorName: "gray200 / gray800"),
+        Color(color: YDSColor.buttonPoint, name: "buttonPoint", basicColorName: "pointColor400 / pointColor400"),
+        Color(color: YDSColor.buttonPointPressed, name: "buttonPointPressed", basicColorName: "pointColor300 / pointColor300"),
+        Color(color: YDSColor.buttonPointBG, name: "buttonPointBG", basicColorName: "pointColor050 / pointColor050"),
+        Color(color: YDSColor.buttonWarned, name: "buttonWarned", basicColorName: "warningRed400 / warningRed400"),
+        Color(color: YDSColor.buttonWarnedPressed, name: "buttonWarnedPressed", basicColorName: "warningRed300 / warningRed300"),
+        Color(color: YDSColor.buttonWarnedBG, name: "buttonWarnedBG", basicColorName: "warningRed050 / warningRed050"),
     ],
     description: "Button"
 )
 
 let bottomBarColors = Colors(
     items: [
-        Color(color: YDSColor.bottomBarNormal, name: "bottomBarNormal", basicColorName: "gray600"),
-        Color(color: YDSColor.bottomBarSelected, name: "bottomBarSelected", basicColorName: "gray800"),
+        Color(color: YDSColor.bottomBarNormal, name: "bottomBarNormal", basicColorName: "gray600 / gray600"),
+        Color(color: YDSColor.bottomBarSelected, name: "bottomBarSelected", basicColorName: "gray800 / gray200"),
     ],
     description: "BottomBar"
 )
 
 let inputFieldColors = Colors(
     items: [
-        Color(color: YDSColor.inputFieldNormal, name: "inputFieldNormal", basicColorName: "white000"),
-        Color(color: YDSColor.inputFieldElevated, name: "inputFieldElevated", basicColorName: "gray100"),
+        Color(color: YDSColor.inputFieldNormal, name: "inputFieldNormal", basicColorName: "white000 / black000"),
+        Color(color: YDSColor.inputFieldElevated, name: "inputFieldElevated", basicColorName: "gray100 / gray900"),
     ],
     description: "InputField"
 )
@@ -101,14 +101,21 @@ let inputFieldColors = Colors(
 
 let toastColors = Colors(
     items: [
-        Color(color: YDSColor.toastBG, name: "toastBG", basicColorName: "gray800"),
+        Color(color: YDSColor.toastBG, name: "toastBG", basicColorName: "gray800 / gray800"),
     ],
     description: "Toast"
 )
 
+let tooltipColors = Colors(
+    items: [
+        Color(color: YDSColor.tooltipBG, name: "tooltipBG", basicColorName: "gray700 / gray700"),
+        Color(color: YDSColor.tooltipBG, name: "tooltipPoint", basicColorName: "gray400 / gray400"),
+    ],
+    description: "Tooltip")
+
 let pressedColors = Colors(
     items: [
-        Color(color: YDSColor.pressed, name: "pressed", basicColorName: "black000A10"),
+        Color(color: YDSColor.pressed, name: "pressed", basicColorName: "black000A10 / black000A10"),
     ],
     description: "Pressed"
 )
@@ -172,6 +179,7 @@ let colors = [
     bottomBarColors,
     inputFieldColors,
     toastColors,
+    tooltipColors,
     pressedColors,
     shadowColors,
     itemColors

--- a/YDS-Storybook/Resources/YDSColorArray.swift
+++ b/YDS-Storybook/Resources/YDSColorArray.swift
@@ -109,7 +109,7 @@ let toastColors = Colors(
 let tooltipColors = Colors(
     items: [
         Color(color: YDSColor.tooltipBG, name: "tooltipBG", basicColorName: "gray700 / gray700"),
-        Color(color: YDSColor.tooltipBG, name: "tooltipPoint", basicColorName: "gray400 / gray400"),
+        Color(color: YDSColor.tooltipBG, name: "tooltipPoint", basicColorName: "pointColor400 / pointColor400"),
     ],
     description: "Tooltip")
 

--- a/YDS-Storybook/Resources/YDSColorArray.swift
+++ b/YDS-Storybook/Resources/YDSColorArray.swift
@@ -109,7 +109,7 @@ let toastColors = Colors(
 let tooltipColors = Colors(
     items: [
         Color(color: YDSColor.tooltipBG, name: "tooltipBG", basicColorName: "gray700 / gray700"),
-        Color(color: YDSColor.tooltipBG, name: "tooltipPoint", basicColorName: "pointColor400 / pointColor400"),
+        Color(color: YDSColor.tooltipPoint, name: "tooltipPoint", basicColorName: "pointColor400 / pointColor400"),
     ],
     description: "Tooltip")
 

--- a/YDS/Source/Atom/YDSButton/YDSBoxButton.swift
+++ b/YDS/Source/Atom/YDSButton/YDSBoxButton.swift
@@ -263,13 +263,13 @@ public class YDSBoxButton: UIButton, YDSButtonProtocol {
                 bgColor = YDSColor.buttonDisabledBG
                 bgPressedColor = YDSColor.buttonDisabledBG
             } else if isWarned {
-                fgColor = YDSColor.buttonReversed
-                fgPressedColor = YDSColor.buttonReversed
+                fgColor = YDSColor.buttonBright
+                fgPressedColor = YDSColor.buttonBright
                 bgColor = YDSColor.buttonWarned
                 bgPressedColor = YDSColor.buttonWarnedPressed
             } else {
-                fgColor = YDSColor.buttonReversed
-                fgPressedColor = YDSColor.buttonReversed
+                fgColor = YDSColor.buttonBright
+                fgPressedColor = YDSColor.buttonBright
                 bgColor = YDSColor.buttonPoint
                 bgPressedColor = YDSColor.buttonPointPressed
             }

--- a/YDS/Source/Component/YDSToast.swift
+++ b/YDS/Source/Component/YDSToast.swift
@@ -71,7 +71,7 @@ public class YDSToast: UIView {
      */
     private let label: YDSLabel = {
         let label = YDSLabel(style: .body2)
-        label.textColor = YDSColor.textReversed
+        label.textColor = YDSColor.textBright
         label.numberOfLines = 0
         return label
     }()

--- a/YDS/Source/Foundation/YDSSemanticColor.swift
+++ b/YDS/Source/Foundation/YDSSemanticColor.swift
@@ -41,7 +41,7 @@ public enum YDSColor {
         return color(light: YDSBasicColor.gray100, dark: YDSBasicColor.gray800)
     }
     
-    public static var bgNormalReversed: UIColor {
+    public static var bgNormalDark: UIColor {
         return color(light: YDSBasicColor.realBlack, dark: YDSBasicColor.realBlack)
     }
     

--- a/YDS/Source/Foundation/YDSSemanticColor.swift
+++ b/YDS/Source/Foundation/YDSSemanticColor.swift
@@ -22,188 +22,199 @@ public enum YDSColor {
     //  MARK: - Background
     
     public static var bgNormal: UIColor {
-        return color(light: YDSBasicColor.white000)
+        return color(light: YDSBasicColor.white000, dark: YDSBasicColor.black000)
     }
     
     public static var bgElevated: UIColor {
-        return color(light: YDSBasicColor.white000)
+        return color(light: YDSBasicColor.white000, dark: YDSBasicColor.black000)
     }
     
     public static var bgRecomment: UIColor {
-        return color(light: YDSBasicColor.gray050)
+        return color(light: YDSBasicColor.gray050, dark: YDSBasicColor.realBlack)
     }
     
     public static var bgSelected: UIColor {
-        return color(light: YDSBasicColor.gray100)
+        return color(light: YDSBasicColor.gray100, dark: YDSBasicColor.gray900)
     }
     
     public static var bgPressed: UIColor {
-        return color(light: YDSBasicColor.gray100)
+        return color(light: YDSBasicColor.gray100, dark: YDSBasicColor.gray800)
     }
     
     public static var bgNormalReversed: UIColor {
-        return color(light: YDSBasicColor.realBlack)
+        return color(light: YDSBasicColor.realBlack, dark: YDSBasicColor.realBlack)
     }
     
     public static var  bgElevatedReversed: UIColor {
-        return color(light: YDSBasicColor.realBlack)
+        return color(light: YDSBasicColor.realBlack, dark: YDSBasicColor.realBlack)
     }
     
     
     //  MARK: - Text
     
     public static var textPrimary: UIColor {
-        return color(light: YDSBasicColor.black000)
+        return color(light: YDSBasicColor.black000, dark: YDSBasicColor.gray100)
     }
     
     public static var textSecondary: UIColor {
-        return color(light: YDSBasicColor.gray900)
+        return color(light: YDSBasicColor.gray900, dark: YDSBasicColor.gray200)
     }
     
     public static var textTertiary: UIColor {
-        return color(light: YDSBasicColor.gray600)
+        return color(light: YDSBasicColor.gray600, dark: YDSBasicColor.gray600)
     }
     
     public static var textDisabled: UIColor {
-        return color(light: YDSBasicColor.gray500)
+        return color(light: YDSBasicColor.gray500, dark: YDSBasicColor.gray700)
     }
     
-    public static var textReversed: UIColor {
-        return color(light: YDSBasicColor.white000)
+    public static var textBright: UIColor {
+        return color(light: YDSBasicColor.white000, dark: YDSBasicColor.white000)
     }
     
     public static var textPointed: UIColor {
-        return color(light: YDSBasicColor.pointColor400)
+        return color(light: YDSBasicColor.pointColor400, dark: YDSBasicColor.pointColor300)
     }
     
     public static var textWarned: UIColor {
-        return color(light: YDSBasicColor.warningRed400)
+        return color(light: YDSBasicColor.warningRed400, dark: YDSBasicColor.warningRed300)
     }
     
     
     //  MARK: - Dim
     
     public static var dimNormal: UIColor {
-        return color(light: YDSBasicColor.gray900A30)
+        return color(light: YDSBasicColor.gray900A30, dark: YDSBasicColor.gray900A30)
     }
     
     public static var dimThick: UIColor {
-        return color(light: YDSBasicColor.gray900A70)
+        return color(light: YDSBasicColor.gray900A70, dark: YDSBasicColor.gray900A70)
     }
     
-    public static var dimThickReversed: UIColor {
-        return color(light: YDSBasicColor.white000A70)
+    public static var dimThickBright: UIColor {
+        return color(light: YDSBasicColor.white000A70, dark: YDSBasicColor.white000A70)
     }
     
     
     //  MARK: - Border
     
     public static var borderThin: UIColor {
-        return color(light: YDSBasicColor.gray100)
+        return color(light: YDSBasicColor.gray100, dark: YDSBasicColor.gray900)
     }
     
     public static var borderNormal: UIColor {
-        return color(light: YDSBasicColor.black000A10)
+        return color(light: YDSBasicColor.black000A10, dark: YDSBasicColor.white000A10)
     }
     
     public static var borderThick: UIColor {
-        return color(light: YDSBasicColor.gray500)
+        return color(light: YDSBasicColor.gray500, dark: YDSBasicColor.gray500)
     }
     
     
     //  MARK: - Button
     
     public static var buttonNormal: UIColor {
-        return color(light: YDSBasicColor.gray700)
+        return color(light: YDSBasicColor.gray700, dark: YDSBasicColor.gray300)
     }
     
     public static var buttonNormalPressed: UIColor {
-        return color(light: YDSBasicColor.gray600)
+        return color(light: YDSBasicColor.gray600, dark: YDSBasicColor.gray200)
     }
     
     public static var buttonBG: UIColor {
-        return color(light: YDSBasicColor.gray200)
+        return color(light: YDSBasicColor.gray200, dark: YDSBasicColor.gray800)
     }
     
     public static var buttonEmojiBG: UIColor {
-        return color(light: YDSBasicColor.gray100)
+        return color(light: YDSBasicColor.gray100, dark: YDSBasicColor.gray900)
     }
     
-    public static var buttonReversed: UIColor {
-        return color(light: YDSBasicColor.white000)
+    public static var buttonBright: UIColor {
+        return color(light: YDSBasicColor.white000, dark: YDSBasicColor.white000)
     }
     
     public static var buttonDisabled: UIColor {
-        return color(light: YDSBasicColor.gray500)
+        return color(light: YDSBasicColor.gray500, dark: YDSBasicColor.gray600)
     }
     
     public static var buttonDisabledBG: UIColor {
-        return color(light: YDSBasicColor.gray200)
+        return color(light: YDSBasicColor.gray200, dark: YDSBasicColor.gray800)
     }
     
     public static var buttonPoint: UIColor {
-        return color(light: YDSBasicColor.pointColor400)
+        return color(light: YDSBasicColor.pointColor400, dark: YDSBasicColor.pointColor400)
     }
     
     public static var buttonPointPressed: UIColor {
-        return color(light: YDSBasicColor.pointColor300)
+        return color(light: YDSBasicColor.pointColor300, dark: YDSBasicColor.pointColor300)
     }
     
     public static var buttonPointBG: UIColor {
-        return color(light: YDSBasicColor.pointColor050)
+        return color(light: YDSBasicColor.pointColor050, dark: YDSBasicColor.pointColor050)
     }
     
     public static var buttonWarned: UIColor {
-        return color(light: YDSBasicColor.warningRed400)
+        return color(light: YDSBasicColor.warningRed400, dark: YDSBasicColor.warningRed400)
     }
     
     public static var buttonWarnedPressed: UIColor {
-        return color(light: YDSBasicColor.warningRed300)
+        return color(light: YDSBasicColor.warningRed300, dark: YDSBasicColor.warningRed300)
     }
     
     public static var buttonWarnedBG: UIColor {
-        return color(light: YDSBasicColor.warningRed050)
+        return color(light: YDSBasicColor.warningRed050, dark: YDSBasicColor.warningRed050)
     }
     
     
     //  MARK: - BottomBar
     
     public static var bottomBarNormal: UIColor {
-        return color(light: YDSBasicColor.gray600)
+        return color(light: YDSBasicColor.gray600, dark: YDSBasicColor.gray600)
     }
     
     public static var bottomBarSelected: UIColor {
-        return color(light: YDSBasicColor.gray800)
+        return color(light: YDSBasicColor.gray800, dark: YDSBasicColor.gray200)
     }
     
     
     //  MARK: - InputField
     
     public static var inputFieldNormal: UIColor {
-        return color(light: YDSBasicColor.white000)
+        return color(light: YDSBasicColor.white000, dark: YDSBasicColor.black000)
     }
     
     public static var inputFieldElevated: UIColor {
-        return color(light: YDSBasicColor.gray100)
+        return color(light: YDSBasicColor.gray100, dark: YDSBasicColor.gray900)
     }
-    
     
     
     //  MARK: - Toast
     
     public static var toastBG: UIColor {
-        return color(light: YDSBasicColor.gray800)
+        return color(light: YDSBasicColor.gray800, dark: YDSBasicColor.gray800)
+    }
+    
+    
+    //  MARK: - Tooltip
+    
+    public static var tooltipBG: UIColor {
+        return color(light: YDSBasicColor.gray700, dark: YDSBasicColor.gray700)
+    }
+    
+    public static var tooltipPoint: UIColor {
+        return color(light: YDSBasicColor.pointColor400, dark: YDSBasicColor.pointColor400)
     }
     
     
     //  MARK: - Pressed
     
     public static var pressed: UIColor {
-        return color(light: YDSBasicColor.black000A10)
+        return color(light: YDSBasicColor.black000A10, dark: YDSBasicColor.black000A10)
     }
     
     
     //  MARK: - Shadow
+    //  다크모드에서는 Shadow를 사용하지 않습니다.
     
     public static var shadowThin: UIColor {
         return color(light: YDSBasicColor.gray400)

--- a/YDS/Source/Foundation/YDSSemanticColor.swift
+++ b/YDS/Source/Foundation/YDSSemanticColor.swift
@@ -45,7 +45,7 @@ public enum YDSColor {
         return color(light: YDSBasicColor.realBlack, dark: YDSBasicColor.realBlack)
     }
     
-    public static var  bgElevatedReversed: UIColor {
+    public static var  bgElevatedDark: UIColor {
         return color(light: YDSBasicColor.realBlack, dark: YDSBasicColor.realBlack)
     }
     


### PR DESCRIPTION
## 📌 Summary
1. Item을 제외하고 다크모드 컬러를 업데이트 했습니다
2. 겸사겸사 이름이 바뀐 컬러 ( ~~Reversed 가 ~~Bright 로 바뀜 )를 업데이트 해주고
3. 새로 생긴 컬러 (tooltip)를 추가해줬습니다

다크모드 도입 초창기이기 때문에 언제든 컬러는 바뀔 수 있습니다

## 💡 Reason
<!-- 이유까지 써주면 좋아요. -->



## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : https://github.com/yourssu/YDS-iOS/issues/114
- 피그마 : https://www.figma.com/file/yVXvVvBKZnG9BBsvdC3J5B/%5B0.-Common%5D-Yourssu-Design-System?node-id=1%3A461
- 관련 문서 : 



## ❗️리뷰 포인트
- YDS/Source/Foundation/YDSSemanticColor.swift
- YDS-Storybook/Resources/YDSColorArray.swift

에서 피그마 상의 다크모드 컬러와 실제 코드에 적용된 다크모드 컬러가 동일한지 일일이 같이 확인해주신 후 어프루브를 눌러주세요


## ⚠️ 주의사항
이 업데이트로 인해 기존에 ~~Reversed 라는 이름을 쓰던 컬러는 모두 ~~Bright 로 바뀌었습니다
따라서 YDS를 사용하는 프로젝트에서 ~~Reversed 컬러를 사용하고 있다면 빌드가 되지 않을 수 있습니다
이 업데이트가 적용된 이후엔 사용처에서 ~~Reversed 컬러를 ~~Bright 컬러로 바꿔주는 작업을 해야합니다

사실 deprecated 경고를 띄울 수도 있지만 YDS는 최신 버전 사용을 지향하는 게 원칙이라서 그냥 없애줍니다
벌써부터 레거시 만들면 귀찮아질지도...

기존 사용하던 코드에 지장이 생길 수 있으므로 이 업데이트 이후 버전은 2.1.0 이 되어야 합니다