### PR TITLE
[Fix/#117] YDS ContentSize 버그

### DIFF
--- a/YDS-Storybook/AtomSampleViewController/TextViewViewController.swift
+++ b/YDS-Storybook/AtomSampleViewController/TextViewViewController.swift
@@ -13,11 +13,11 @@ public enum YDSPlaceholder {
 }
 
 class TextViewViewController: StoryBookViewController {
-    private lazy var textView = YDSTextView(placeholder: YDSPlaceholder.comment, maxHeight: maxHeight)
+    private lazy var textView = YDSTextView(maxHeight: maxHeight)
     private lazy var titleLabel: YDSLabel = {
         let label = YDSLabel(style: .subtitle2)
         label.textColor = YDSColor.textPrimary
-        label.text = "isShowingPlaceholder"
+        label.text = "TextView.text.isEmpty"
         return label
     }()
     private lazy var stateLabel: YDSLabel = {
@@ -29,15 +29,14 @@ class TextViewViewController: StoryBookViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        stateLabel.text = true.description
-        
         textView.delegate = self
-        textView.placeholderDelegate = self
         textView.isScrollEnabled = false
         textView.isEditable = true
         textView.textContainerInset = .init(top: 12, left: 0, bottom: 12, right: 0)
+        textView.placeholder = YDSPlaceholder.comment
         
         setupView()
+        stateLabel.text = textView.attributedText.isEmpty.description
     }
     
     private let maxHeight: CGFloat = 150
@@ -89,21 +88,10 @@ class TextViewViewController: StoryBookViewController {
     }
 }
 
-extension TextViewViewController: YDSTextViewPlaceholderDelegate {
-    func textView(_ textView: YDSTextView, shouldShowPlaceholder: Bool) {
-        stateLabel.text = shouldShowPlaceholder.description
-    }
-}
-
 extension TextViewViewController: UITextViewDelegate {
-    func textViewDidEndEditing(_ textView: UITextView) {
+    func textViewDidChange(_ textView: UITextView) {
         guard let textView = textView as? YDSTextView else { return }
-        textView.showPlaceholderIfNeeded()
-    }
-    
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        guard let textView = textView as? YDSTextView else { return }
-        textView.hidePlaceholderIfNeeded()
+        stateLabel.text = textView.attributedText.isEmpty.description
     }
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {

--- a/YDS-Storybook/AtomSampleViewController/TextViewViewController.swift
+++ b/YDS-Storybook/AtomSampleViewController/TextViewViewController.swift
@@ -14,11 +14,25 @@ public enum YDSPlaceholder {
 
 class TextViewViewController: StoryBookViewController {
     private lazy var textView = YDSTextView(placeholder: YDSPlaceholder.comment, maxHeight: maxHeight)
+    private lazy var titleLabel: YDSLabel = {
+        let label = YDSLabel(style: .subtitle2)
+        label.textColor = YDSColor.textPrimary
+        label.text = "isShowingPlaceholder"
+        return label
+    }()
+    private lazy var stateLabel: YDSLabel = {
+        let label = YDSLabel(style: .body2)
+        label.textColor = YDSColor.textSecondary
+        return label
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        stateLabel.text = true.description
+        
         textView.delegate = self
+        textView.placeholderDelegate = self
         textView.isScrollEnabled = false
         textView.isEditable = true
         textView.textContainerInset = .init(top: 12, left: 0, bottom: 12, right: 0)
@@ -43,7 +57,7 @@ class TextViewViewController: StoryBookViewController {
     }
     
     private func setViewHierarchy() {
-        sampleView.addSubviews(textView)
+        sampleView.addSubviews(textView, titleLabel, stateLabel)
     }
     
     private func setAutolayout() {
@@ -52,6 +66,16 @@ class TextViewViewController: StoryBookViewController {
             $0.height.lessThanOrEqualTo(maxHeight)
             $0.width.equalTo(282)
             $0.centerX.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(textView.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview().inset(30)
+        }
+        
+        stateLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom)
+            $0.leading.trailing.equalToSuperview().inset(30)
             $0.bottom.equalToSuperview().inset(12)
         }
     }
@@ -62,6 +86,12 @@ class TextViewViewController: StoryBookViewController {
         if touch.view != textView {
             view.endEditing(true)
         }
+    }
+}
+
+extension TextViewViewController: YDSTextViewPlaceholderDelegate {
+    func textView(_ textView: YDSTextView, shouldShowPlaceholder: Bool) {
+        stateLabel.text = shouldShowPlaceholder.description
     }
 }
 

--- a/YDS-Storybook/Extension/Optional+isEmpty.swift
+++ b/YDS-Storybook/Extension/Optional+isEmpty.swift
@@ -1,8 +1,8 @@
 //
 //  Optional+isEmpty.swift
-//  YDS
+//  YDS-Storybook
 //
-//  Created by 강민석 on 2022/03/13.
+//  Created by 강민석 on 2022/03/21.
 //
 
 import Foundation

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		C37F356D27DE3475007DF859 /* YDSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F356C27DE3475007DF859 /* YDSTextView.swift */; };
 		C37F357027DE34A3007DF859 /* Optional+isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F356F27DE34A3007DF859 /* Optional+isEmpty.swift */; };
 		C37F357227DE34FE007DF859 /* TextViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F357127DE34FE007DF859 /* TextViewViewController.swift */; };
+		C3A3498627E710F900005034 /* Optional+isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A3498527E710F900005034 /* Optional+isEmpty.swift */; };
 		C79DF3EA279F3868009763AC /* BottomSheetPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79DF3E9279F3868009763AC /* BottomSheetPageViewController.swift */; };
 		C7F6908927DDCD17002B63C9 /* IconsPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F6908827DDCD17002B63C9 /* IconsPageViewController.swift */; };
 		C7F6908B27DDCDD3002B63C9 /* IconsListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F6908A27DDCDD3002B63C9 /* IconsListTableViewController.swift */; };
@@ -218,6 +219,7 @@
 		C37F356C27DE3475007DF859 /* YDSTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTextView.swift; sourceTree = "<group>"; };
 		C37F356F27DE34A3007DF859 /* Optional+isEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+isEmpty.swift"; sourceTree = "<group>"; };
 		C37F357127DE34FE007DF859 /* TextViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewViewController.swift; sourceTree = "<group>"; };
+		C3A3498527E710F900005034 /* Optional+isEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+isEmpty.swift"; sourceTree = "<group>"; };
 		C79DF3E9279F3868009763AC /* BottomSheetPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheetPageViewController.swift; sourceTree = "<group>"; };
 		C7F6908827DDCD17002B63C9 /* IconsPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconsPageViewController.swift; sourceTree = "<group>"; };
 		C7F6908A27DDCDD3002B63C9 /* IconsListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconsListTableViewController.swift; sourceTree = "<group>"; };
@@ -291,6 +293,7 @@
 			isa = PBXGroup;
 			children = (
 				532DBFD126EC7323008C2354 /* UITableView+Generic.swift */,
+				C3A3498527E710F900005034 /* Optional+isEmpty.swift */,
 				532DBFD426EC734F008C2354 /* UIView+AddSubviews.swift */,
 				532DBFD626EC736C008C2354 /* UIStackView+AddArrangedSubviews.swift */,
 				532DBFD826EC7863008C2354 /* UIViewController+Embed.swift */,
@@ -810,6 +813,7 @@
 				537A0ACE26C4188C00142DCE /* DoubleTitleTopBarSampleViewController.swift in Sources */,
 				537FFAA626C3E6F800270C22 /* TopBarSampleViewController.swift in Sources */,
 				53E26E8626F0619E0036648E /* TypographiesPageViewController.swift in Sources */,
+				C3A3498627E710F900005034 /* Optional+isEmpty.swift in Sources */,
 				537A0AD026C4189700142DCE /* SingleTitleTopBarSampleViewController.swift in Sources */,
 				53E26E8A26F062180036648E /* TypographiesListItemCell.swift in Sources */,
 				53EFF5D426BBC26900732DCF /* ToastPageViewController.swift in Sources */,

--- a/YDS/Source/Atom/YDSTextView.swift
+++ b/YDS/Source/Atom/YDSTextView.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+public protocol YDSTextViewPlaceholderDelegate: AnyObject {
+    func textView(_ textView: YDSTextView, shouldShowPlaceholder: Bool)
+}
+
 public class YDSTextView: UITextView {
     public var style : String.TypoStyle {
         didSet { setAttributedText() }
@@ -27,6 +31,8 @@ public class YDSTextView: UITextView {
     public var lineBreakStrategy: NSParagraphStyle.LineBreakStrategy? {
         didSet { setAttributedText() }
     }
+    
+    public weak var placeholderDelegate: YDSTextViewPlaceholderDelegate?
     
     private let placeholder: String
     public private(set) var isShowingPlaceholder: Bool = false
@@ -63,6 +69,7 @@ public class YDSTextView: UITextView {
             text = nil
             textColor = YDSColor.textSecondary
             isShowingPlaceholder.toggle()
+            placeholderDelegate?.textView(self, shouldShowPlaceholder: isShowingPlaceholder)
         }
     }
     
@@ -71,6 +78,7 @@ public class YDSTextView: UITextView {
             text = placeholder
             textColor = YDSColor.textTertiary
             isShowingPlaceholder.toggle()
+            placeholderDelegate?.textView(self, shouldShowPlaceholder: isShowingPlaceholder)
         }
     }
     

--- a/YDS/Source/Atom/YDSTextView.swift
+++ b/YDS/Source/Atom/YDSTextView.swift
@@ -55,6 +55,7 @@ public class YDSTextView: UITextView {
     public override func layoutSubviews() {
         super.layoutSubviews()
         isScrollEnabled = isOverHeight
+        invalidateIntrinsicContentSize()
     }
     
     public func hidePlaceholderIfNeeded() {

--- a/YDS/Source/Atom/YDSTextView.swift
+++ b/YDS/Source/Atom/YDSTextView.swift
@@ -56,6 +56,7 @@ public class YDSTextView: UITextView {
         self.style = style
         self.maxHeight = maxHeight
         super.init(frame: .zero, textContainer: nil)
+        self.tintColor = YDSColor.textPointed
         setTextStyle()
     }
     

--- a/YDS/Source/Atom/YDSTextView.swift
+++ b/YDS/Source/Atom/YDSTextView.swift
@@ -29,7 +29,7 @@ public class YDSTextView: UITextView {
     }
     
     private let placeholder: String
-    private(set) var isShowingPlaceholder: Bool = false
+    public private(set) var isShowingPlaceholder: Bool = false
     private let maxHeight: CGFloat?
     
     private var isOverHeight: Bool {

--- a/YDS/Source/Extension/Optional+isEmpty.swift
+++ b/YDS/Source/Extension/Optional+isEmpty.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-extension Optional where Wrapped == NSAttributedString {
+public extension Optional where Wrapped == NSAttributedString {
     var isEmpty: Bool {
         switch self {
         case .none:


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->

ContentSize가 maxHeight를 넘어서 ScrollEnable이 되고난 후에,
Content를 지우면 다시 원래 사이즈로 돌아가지 않고 maxHeight를 유지해서
이를 수정했습니다.


## 💡 Reason
<!-- 이유까지 써주면 좋아요. -->

TextView의 isScrollEnable가 true면 자동으로 사이즈 조절이 되지 않기 때문으로 보여서
intrinsicContentSize를 다시 계산하게 했습니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : Closes #117 
- 피그마 : 
- 관련 문서 : 



## 📄 More File Description

추가로 isShowingPlaceholder도 public으로 변경했습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->


### before

https://user-images.githubusercontent.com/19145853/158402400-d8f6dd3f-5928-4557-92cc-0448d46347ae.mp4




### After


https://user-images.githubusercontent.com/19145853/158402415-aeb59c25-3424-4940-9592-d71ec329985e.mp4

