### PR TITLE
[#119] EmojiButton 기본 배경색상 지정

### DIFF
--- a/YDS/Source/Atom/YDSEmojiButton.swift
+++ b/YDS/Source/Atom/YDSEmojiButton.swift
@@ -105,6 +105,7 @@ public class YDSEmojiButton: UIControl {
         super.init(frame: .zero)
         setBorderColor()
         setEmojiButtonSize()
+        setColorBasedOnIsSelected()
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
기본 지정 색상을 설정합니다.


## 💡 Reason
<!-- 이유까지 써주면 좋아요. -->
기존 스토리북배경 색상때문에 button의 기본 배경이 지정이되어 있지 않다는 사실을 몰랐습니다..ㅎ..ㅎ


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 :  #119 
- 피그마 : 
- 관련 문서 : 

 #120  이전 PR 

## 📄 More File Description



## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
<img width="277" alt="스크린샷 2022-03-24 오전 2 21 42" src="https://user-images.githubusercontent.com/72497599/159758948-a1b72576-f4b1-4d23-9338-e5f0c584eb51.png">
배경색 바꾸고 테스트 했습니다!

