### PR TITLE
[#109] YDSTooltip (리뷰 반영한 툴팁)

### DIFF
--- a/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipPageViewController.swift
+++ b/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipPageViewController.swift
@@ -10,12 +10,18 @@ import YDS
 import SnapKit
 
 class TooltipPageViewController: StoryBookViewController {
-
-    let tooltip: YDSTooltip = {
-        let tooltip = YDSTooltip(text: "",
-                                 color: .tooltipPoint,
-                                 tailPosition: .bottomRight,
-                                 duration: .short)
+    
+    private struct TooltipModel {
+        var text: String = ""
+        var color: YDSTooltip.TooltipColor = .tooltipBG
+        var tailPosition: YDSTooltip.TailPosition = .bottomRight
+        var duration: YDSTooltip.TooltipDuration = .long
+    }
+    
+    private var tooltipInfo: TooltipModel = TooltipModel()
+    
+    private var tooltip: YDSTooltip = {
+        let tooltip = YDSTooltip()
         return tooltip
     }()
 
@@ -78,25 +84,28 @@ class TooltipPageViewController: StoryBookViewController {
     private func addOptions() {
         addOption(description: "text",
                   defaultValue: "홈에서 실시간 피드를 확인해보세요!") { [weak self] value in
-            self?.tooltip.text = value ?? ""
+            self?.tooltipInfo.text = value ?? ""
+            self?.resetupTooltip()
         }
 
         addOption(description: "color",
                   cases: YDSTooltip.TooltipColor.allCases,
                   defaultIndex: 0) { [weak self] value in
-            self?.tooltip.color = value
+            self?.tooltipInfo.color = value
+            self?.resetupTooltip()
         }
 
         addOption(description: "tailPosition",
                   cases: YDSTooltip.TailPosition.allCases,
                   defaultIndex: 2) { [weak self] value in
-            self?.tooltip.tailPosition = value
+            self?.tooltipInfo.tailPosition = value
+            self?.resetupTooltip()
         }
 
         addOption(description: "duration",
                   cases: YDSTooltip.TooltipDuration.allCases,
                   defaultIndex: 1) { [weak self] value in
-            self?.tooltip.duration = value
+            self?.tooltipInfo.duration = value
         }
     }
 
@@ -109,17 +118,30 @@ class TooltipPageViewController: StoryBookViewController {
         switch(sender) {
         case pushButton:
             let sampleViewController: TooltipSampleViewController = {
-                let viewController = TooltipSampleViewController()
-                viewController.tooltip.text = self.tooltip.text
-                viewController.tooltip.color = self.tooltip.color
-                viewController.tooltip.tailPosition = self.tooltip.tailPosition
-                viewController.tooltip.duration = self.tooltip.duration
+                let viewController = TooltipSampleViewController(text: tooltipInfo.text,
+                                                                 color: tooltipInfo.color,
+                                                                 tailPosition: tooltipInfo.tailPosition,
+                                                                 duration: tooltipInfo.duration)
                 return viewController
             }()
             
             self.navigationController?.pushViewController(sampleViewController, animated: true)
         default:
             return
+        }
+    }
+    
+    private func resetupTooltip() {
+        tooltip.removeFromSuperview()
+        tooltip = YDSTooltip(text: tooltipInfo.text ,
+                                   color: tooltipInfo.color,
+                                   tailPosition: tooltipInfo.tailPosition,
+                                   duration: tooltipInfo.duration)
+        tooltip.alpha = 1.0
+        
+        sampleView.addSubview(tooltip)
+        tooltip.snp.makeConstraints {
+            $0.center.equalToSuperview()
         }
     }
 }

--- a/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipPageViewController.swift
+++ b/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipPageViewController.swift
@@ -1,0 +1,137 @@
+//
+//  TooltipPageViewController.swift
+//  YDS-Storybook
+//
+//  Created by Yonghyun on 2022/03/26.
+//
+
+import UIKit
+import YDS
+import SnapKit
+
+class TooltipPageViewController: StoryBookViewController {
+
+    let tooltip: YDSTooltip = {
+        let tooltip = YDSTooltip(text: "",
+                                 color: .tooltipPoint,
+                                 tailPosition: .bottomRight,
+                                 duration: .short)
+        return tooltip
+    }()
+
+    private let pushButton: YDSBoxButton = {
+        let button = YDSBoxButton()
+        button.size = .large
+        button.rounding = .r8
+        button.type = .filled
+        button.text = "샘플 페이지 보기"
+        return button
+    }()
+    
+    private let spacer: UIView = {
+        let view = UIView()
+        view.snp.makeConstraints {
+            $0.height.equalTo(60)
+        }
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        addOptions()
+        setupView()
+        registerTapAction()
+    }
+
+    private func setupView() {
+        setViewProperty()
+        setLayouts()
+    }
+
+    private func setViewProperty() {
+        self.title = "Tooltip"
+        self.tooltip.alpha = 1.0
+    }
+
+    private func setLayouts() {
+        setViewHierarchy()
+        setAutolayout()
+    }
+
+    private func setViewHierarchy() {
+        sampleView.addSubview(tooltip)
+        self.view.addSubviews(pushButton)
+        stackView.addArrangedSubview(spacer)
+    }
+
+    private func setAutolayout() {
+        tooltip.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        pushButton.snp.makeConstraints {
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).offset(-32)
+            $0.leading.trailing.equalTo(self.view.safeAreaLayoutGuide).inset(16)
+        }
+    }
+
+    private func addOptions() {
+        addOption(description: "text",
+                  defaultValue: "홈에서 실시간 피드를 확인해보세요!") { [weak self] value in
+            self?.tooltip.text = value
+        }
+
+        addOption(description: "color",
+                  cases: YDSTooltip.TooltipColor.allCases,
+                  defaultIndex: 0) { [weak self] value in
+            self?.tooltip.color = value
+        }
+
+        addOption(description: "tailPosition",
+                  cases: YDSTooltip.TailPosition.allCases,
+                  defaultIndex: 2) { [weak self] value in
+            self?.tooltip.tailPosition = value
+        }
+
+        addOption(description: "duration",
+                  cases: YDSTooltip.TooltipDuration.allCases,
+                  defaultIndex: 1) { [weak self] value in
+            self?.tooltip.duration = value
+        }
+    }
+
+    private func registerTapAction() {
+        pushButton.addTarget(self, action: #selector(buttonTapAction(_:)), for: .touchUpInside)
+    }
+
+    @objc
+    private func buttonTapAction(_ sender: UIButton) {
+        switch(sender) {
+        case pushButton:
+            let sampleViewController: TooltipSampleViewController = {
+                let viewController = TooltipSampleViewController()
+                viewController.tooltip.text = self.tooltip.text
+                viewController.tooltip.color = self.tooltip.color
+                viewController.tooltip.tailPosition = self.tooltip.tailPosition
+                viewController.tooltip.duration = self.tooltip.duration
+                return viewController
+            }()
+            
+            self.navigationController?.pushViewController(sampleViewController, animated: true)
+        default:
+            return
+        }
+    }
+}
+
+extension YDSTooltip.TooltipColor: CaseIterable {
+    public static var allCases: [YDSTooltip.TooltipColor] = [.tooltipPoint, .tooltipBG]
+}
+
+extension YDSTooltip.TailPosition: CaseIterable {
+    public static var allCases: [YDSTooltip.TailPosition] = [.left, .right, .topLeft, .bottomLeft, .topCenter, .bottomCenter, .topRight, .bottomRight]
+}
+
+extension YDSTooltip.TooltipDuration: CaseIterable {
+    public static var allCases: [YDSTooltip.TooltipDuration] = [.short, .long]
+}

--- a/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipPageViewController.swift
+++ b/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipPageViewController.swift
@@ -78,7 +78,7 @@ class TooltipPageViewController: StoryBookViewController {
     private func addOptions() {
         addOption(description: "text",
                   defaultValue: "홈에서 실시간 피드를 확인해보세요!") { [weak self] value in
-            self?.tooltip.text = value
+            self?.tooltip.text = value ?? ""
         }
 
         addOption(description: "color",

--- a/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipSampleViewController.swift
+++ b/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipSampleViewController.swift
@@ -11,13 +11,22 @@ import SnapKit
 
 class TooltipSampleViewController: UIViewController {
     
-    let tooltip: YDSTooltip = {
-        let tooltip = YDSTooltip(text: "",
-                                 color: .tooltipPoint,
-                                 tailPosition: .bottomRight,
-                                 duration: .short)
-        return tooltip
-    }()
+    private let tooltip: YDSTooltip
+    
+    init(text: String,
+         color: YDSTooltip.TooltipColor,
+         tailPosition: YDSTooltip.TailPosition,
+         duration: YDSTooltip.TooltipDuration) {
+        tooltip = YDSTooltip(text: text,
+                             color: color,
+                             tailPosition: tailPosition,
+                             duration: duration)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipSampleViewController.swift
+++ b/YDS-Storybook/ComponentSampleViewController/Tooltip/TooltipSampleViewController.swift
@@ -1,0 +1,55 @@
+//
+//  TooltipSampleViewController.swift
+//  YDS-Storybook
+//
+//  Created by Yonghyun on 2022/04/03.
+//
+
+import UIKit
+import YDS
+import SnapKit
+
+class TooltipSampleViewController: UIViewController {
+    
+    let tooltip: YDSTooltip = {
+        let tooltip = YDSTooltip(text: "",
+                                 color: .tooltipPoint,
+                                 tailPosition: .bottomRight,
+                                 duration: .short)
+        return tooltip
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tooltip.show()
+    }
+    
+    private func setupView() {
+        setProperties()
+        setLayouts()
+    }
+    
+    private func setProperties() {
+        self.view.backgroundColor = YDSColor.bgNormal
+    }
+    
+    private func setLayouts() {
+        setViewHierarchy()
+        setAutolayout()
+    }
+    
+    private func setViewHierarchy() {
+        self.view.addSubview(tooltip)
+    }
+    
+    private func setAutolayout() {
+        tooltip.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+}

--- a/YDS-Storybook/PageListViewController.swift
+++ b/YDS-Storybook/PageListViewController.swift
@@ -58,6 +58,7 @@ class PageListViewController: UIViewController {
         Page(title: "SingleTitleTopBar", vc: SingleTitleTopBarPageViewController.self),
         Page(title: "DoubleTitleTopBar", vc: DoubleTitleTopBarPageViewController.self),
         Page(title: "BottomBarController", vc: BottomBarControllerPageViewController.self),
+        Page(title: "Tooltip", vc: TooltipPageViewController.self),
     ]
 
     

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -93,6 +93,9 @@
 		53EFF5CE26BA9CD400732DCF /* YDSToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EFF5CD26BA9CD400732DCF /* YDSToast.swift */; };
 		53EFF5D426BBC26900732DCF /* ToastPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EFF5D326BBC26900732DCF /* ToastPageViewController.swift */; };
 		53FE9B6D26C524C400107148 /* YDSButtonProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C9F6F826B5546400EF7B86 /* YDSButtonProtocol.swift */; };
+		C350ABE22808587600BFC9C0 /* TooltipPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C350ABE12808587600BFC9C0 /* TooltipPageViewController.swift */; };
+		C350ABE42808589200BFC9C0 /* TooltipSampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C350ABE32808589200BFC9C0 /* TooltipSampleViewController.swift */; };
+		C350ABE6280858B900BFC9C0 /* YDSTooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C350ABE5280858B900BFC9C0 /* YDSTooltip.swift */; };
 		C37F356D27DE3475007DF859 /* YDSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F356C27DE3475007DF859 /* YDSTextView.swift */; };
 		C37F357027DE34A3007DF859 /* Optional+isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F356F27DE34A3007DF859 /* Optional+isEmpty.swift */; };
 		C37F357227DE34FE007DF859 /* TextViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F357127DE34FE007DF859 /* TextViewViewController.swift */; };
@@ -220,6 +223,9 @@
 		53EB9FEF269DC45D00B7D14A /* YDSIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSIcon.swift; sourceTree = "<group>"; };
 		53EFF5CD26BA9CD400732DCF /* YDSToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSToast.swift; sourceTree = "<group>"; };
 		53EFF5D326BBC26900732DCF /* ToastPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastPageViewController.swift; sourceTree = "<group>"; };
+		C350ABE12808587600BFC9C0 /* TooltipPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPageViewController.swift; sourceTree = "<group>"; };
+		C350ABE32808589200BFC9C0 /* TooltipSampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipSampleViewController.swift; sourceTree = "<group>"; };
+		C350ABE5280858B900BFC9C0 /* YDSTooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTooltip.swift; sourceTree = "<group>"; };
 		C37F356C27DE3475007DF859 /* YDSTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTextView.swift; sourceTree = "<group>"; };
 		C37F356F27DE34A3007DF859 /* Optional+isEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+isEmpty.swift"; sourceTree = "<group>"; };
 		C37F357127DE34FE007DF859 /* TextViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewViewController.swift; sourceTree = "<group>"; };
@@ -503,6 +509,7 @@
 				53EFF5CD26BA9CD400732DCF /* YDSToast.swift */,
 				5359A5BC26BEC30300FCCECC /* YDSBottomBarController.swift */,
 				539110BD26C373D20094FD08 /* TopBar */,
+				C350ABE5280858B900BFC9C0 /* YDSTooltip.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -513,8 +520,18 @@
 				53EFF5D326BBC26900732DCF /* ToastPageViewController.swift */,
 				5359A5C026BEC99700FCCECC /* BottomBarControllerPageViewController.swift */,
 				537A0AD126C4189D00142DCE /* TopBar */,
+				C350ABE02808585500BFC9C0 /* Tooltip */,
 			);
 			path = ComponentSampleViewController;
+			sourceTree = "<group>";
+		};
+		C350ABE02808585500BFC9C0 /* Tooltip */ = {
+			isa = PBXGroup;
+			children = (
+				C350ABE12808587600BFC9C0 /* TooltipPageViewController.swift */,
+				C350ABE32808589200BFC9C0 /* TooltipSampleViewController.swift */,
+			);
+			path = Tooltip;
 			sourceTree = "<group>";
 		};
 		C37F356E27DE348C007DF859 /* Extension */ = {
@@ -748,6 +765,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				537A0AD326C51DB000142DCE /* YDSButtonProtocol.swift in Sources */,
+				C350ABE6280858B900BFC9C0 /* YDSTooltip.swift in Sources */,
 				C37F357027DE34A3007DF859 /* Optional+isEmpty.swift in Sources */,
 				53FE9B6D26C524C400107148 /* YDSButtonProtocol.swift in Sources */,
 				539110B826C1484A0094FD08 /* YDSNavigationController.swift in Sources */,
@@ -823,10 +841,12 @@
 				53C9F6F726B54B4000EF7B86 /* PlainButtonPageViewController.swift in Sources */,
 				DDFBCFFF26739A6900C5F409 /* AppDelegate.swift in Sources */,
 				53441AFE26AF1E7E00CB6BC9 /* OptionalImageControllerView.swift in Sources */,
+				C350ABE22808587600BFC9C0 /* TooltipPageViewController.swift in Sources */,
 				C7F6908927DDCD17002B63C9 /* IconsPageViewController.swift in Sources */,
 				532DBFD526EC734F008C2354 /* UIView+AddSubviews.swift in Sources */,
 				537A0ACE26C4188C00142DCE /* DoubleTitleTopBarSampleViewController.swift in Sources */,
 				537FFAA626C3E6F800270C22 /* TopBarSampleViewController.swift in Sources */,
+				C350ABE42808589200BFC9C0 /* TooltipSampleViewController.swift in Sources */,
 				53E26E8626F0619E0036648E /* TypographiesPageViewController.swift in Sources */,
 				C3985FB627F832EA00389A22 /* SceneDelegate.swift in Sources */,
 				C3A3498627E710F900005034 /* Optional+isEmpty.swift in Sources */,

--- a/YDS/Source/Component/YDSTooltip.swift
+++ b/YDS/Source/Component/YDSTooltip.swift
@@ -48,25 +48,14 @@ final public class YDSTooltip: UIView {
     
     //  MARK: - 외부에서 지정할 수 없는 속성
     
-    private var tailLayer: CAShapeLayer = CAShapeLayer() {
-        didSet {
-            setNeedsLayout()
-        }
-    }
-
-    /// 사용자의 탭을 확인하는 Recognizer
-    private lazy var tapRecognizer: UITapGestureRecognizer = {
-        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapOnScreen))
-        tapRecognizer.numberOfTapsRequired = 1
-        return tapRecognizer
-    }()
-
-    ///  화면 전체 영역을 차지하고 tapRecognizer를 연결 할 뷰
-    private lazy var dismissView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .clear
-        view.frame = UIScreen.main.bounds
-        return view
+    /// 툴팁의 꼬리 부분을 표현하는 Layer
+    private var tailLayer: CAShapeLayer = CAShapeLayer()
+    
+    ///  화면 전체 영역을 차지하고 사용자의 탭을 확인하는 UIControl
+    private lazy var touchControl: UIControl = {
+        let control = UIControl()
+        control.frame = UIScreen.main.bounds
+        return control
     }()
     
     
@@ -186,7 +175,7 @@ final public class YDSTooltip: UIView {
     /// 애니메이션으로 툴팁이 뷰에 보여지고 지정된 duration 동안 유지된 후 사라지게 합니다.
     public func show() {
         guard let superView = self.superview else { return }
-        self.addDismissView(on: superView)
+        self.addTouchControl(on: superView)
         
         UIView.animate(withDuration: YDSAnimation.Duration.medium,
                        animations: { self.alpha = 1.0 },
@@ -198,11 +187,10 @@ final public class YDSTooltip: UIView {
         })
     }
     
-    /// 화면 전체 영역을 차지하고 tap을 확인할 수 있는 뷰를 추가합니다.
-    private func addDismissView(on superView: UIView) {
-        superView.addSubview(self.dismissView)
-        self.dismissView.addGestureRecognizer(self.tapRecognizer)
-        self.tapRecognizer.isEnabled = true
+    /// 화면 전체 영역을 차지하고 tap을 확인할 수 있는 UIControl을 추가합니다.
+    private func addTouchControl(on superView: UIView) {
+        superview?.addSubview(touchControl)
+        touchControl.addTarget(self, action: #selector(didTapOnScreen), for: .touchDown)
     }
     
     /// 툴팁을 뷰에서 없애줍니다.
@@ -210,9 +198,8 @@ final public class YDSTooltip: UIView {
         UIView.animate(withDuration: YDSAnimation.Duration.medium,
                        animations: { self.alpha = 0 },
                        completion: { [weak self] _ in
-            self?.dismissView.removeFromSuperview()
+            self?.touchControl.removeFromSuperview()
             self?.removeFromSuperview()
-            self?.tapRecognizer.isEnabled = false
         })
     }
 

--- a/YDS/Source/Component/YDSTooltip.swift
+++ b/YDS/Source/Component/YDSTooltip.swift
@@ -12,7 +12,7 @@ final public class YDSTooltip: UIView {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     /// 툴팁 내부 label의 텍스트를 설정할 때 사용합니다.
-    public var text: String? {
+    public var text: String {
         didSet {
             setNeedsLayout()
         }
@@ -114,6 +114,7 @@ final public class YDSTooltip: UIView {
     private func setProperties() {
         self.layer.cornerRadius = 8
         self.alpha = 0.0
+        self.layer.insertSublayer(tailLayer, at: 0)
     }
     
     
@@ -126,10 +127,8 @@ final public class YDSTooltip: UIView {
     
     /// 툴팁의 꼬리 부분을 그립니다.
     private func makeTail() {
-        tailLayer.removeFromSuperlayer()
-        
         let path = UIBezierPath()
-
+        
         switch tailPosition {
         case .left, .right:
             let point1 = CGPoint(x: (tailPosition == .left) ? (0) : (self.frame.size.width),
@@ -179,8 +178,6 @@ final public class YDSTooltip: UIView {
         
         tailLayer.path = path.cgPath
         tailLayer.fillColor = (color == .tooltipBG) ? (YDSColor.tooltipBG.cgColor) : (YDSColor.tooltipPoint.cgColor)
-        
-        self.layer.insertSublayer(tailLayer, at: 0)
     }
     
     /// 애니메이션으로 툴팁이 뷰에 보여지고 지정된 duration 동안 유지된 후 사라지게 합니다.

--- a/YDS/Source/Component/YDSTooltip.swift
+++ b/YDS/Source/Component/YDSTooltip.swift
@@ -1,0 +1,271 @@
+//
+//  YDSTooltip.swift
+//  YDS
+//
+//  Created by Yonghyun on 2022/03/26.
+//
+
+import UIKit
+
+final public class YDSTooltip: UIView {
+    
+    //  MARK: - 외부에서 지정할 수 있는 속성
+    
+    /// 툴팁 내부 label의 텍스트를 설정할 때 사용합니다.
+    public var text: String? {
+        didSet {
+            label.text = text
+        }
+    }
+    
+    /// 툴팁의 색깔을 설정합니다.
+    public var color: TooltipColor {
+        didSet {
+            self.backgroundColor = color == .tooltipBG ? YDSColor.tooltipBG : YDSColor.tooltipPoint
+            makeTail()
+        }
+    }
+    
+    /// 툴팁의 꼬리 위치를 설정할 때 사용합니다.
+    public var tailPosition: TailPosition {
+        didSet {
+            makeTail()
+        }
+    }
+    
+    /// 툴팁이 뷰에 유지되는 시간을 설정할 때 사용합니다.
+    public var duration: TooltipDuration
+    
+    
+    // MARK: - 뷰
+    
+    /// 툴팁 내부에서 텍스트를 보여주는 label
+    private let label: YDSLabel = {
+        let label = YDSLabel(style: .caption0)
+        label.textColor = YDSColor.textBright
+        label.numberOfLines = 1
+        return label
+    }()
+    
+    //  MARK: - 외부에서 지정할 수 없는 속성
+
+    /// 사용자의 탭을 확인하는 Recognizer
+    private lazy var tapRecognizer: UITapGestureRecognizer = {
+        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapOnScreen))
+        tapRecognizer.numberOfTapsRequired = 1
+        return tapRecognizer
+    }()
+
+    ///  화면 전체 영역을 차지하고 tapRecognizer를 연결 할 뷰
+    private lazy var dismissView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.frame = UIScreen.main.bounds
+        return view
+    }()
+    
+    
+    // MARK: - 메소드
+    
+    public init(text: String, color: TooltipColor, tailPosition: TailPosition, duration: TooltipDuration) {
+        self.text = text
+        self.color = color
+        self.tailPosition = tailPosition
+        self.duration = duration
+        super.init(frame: .zero)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// 뷰를 세팅합니다.
+    private func setupView() {
+        setLayouts()
+        setProperties()
+    }
+    
+    /// 레이아웃을 세팅합니다.
+    private func setLayouts() {
+        setViewHierarchy()
+        setAutolayout()
+    }
+    
+    /// 뷰의 위계를 세팅합니다.
+    private func setViewHierarchy() {
+        self.addSubview(label)
+    }
+    
+    /// 뷰의 오토레이아웃을 세팅합니다.
+    private func setAutolayout() {
+        label.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(Dimension.Margin.horizontal)
+            $0.top.bottom.equalToSuperview().inset(Dimension.Margin.vertical)
+        }
+    }
+    
+    /// 뷰의 프로퍼티를 세팅합니다.
+    private func setProperties() {
+        self.layer.cornerRadius = 8
+        self.alpha = 0.0
+    }
+    
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        makeTail()
+    }
+    
+    /// 툴팁의 꼬리 부분을 그립니다.
+    private func makeTail() {
+        if let firstLayer = self.layer.sublayers?.first {
+            if firstLayer is CAShapeLayer {
+                firstLayer.removeFromSuperlayer()
+            }
+        }
+        
+        let path = UIBezierPath()
+
+        switch tailPosition {
+        case .left, .right:
+            let point1 = CGPoint(x: tailPosition == .left ? 0 : self.frame.size.width,
+                                 y: Dimension.Tail.start)
+            let point2 = CGPoint(x: tailPosition == .left ? point1.x - Dimension.Tail.height : point1.x + Dimension.Tail.height,
+                                 y: point1.y + Dimension.Tail.width/2)
+            let point3 = CGPoint(x: point1.x,
+                                 y: point1.y + Dimension.Tail.width)
+            path.move(to: point1)
+            path.addLine(to: point2)
+            path.addLine(to: point3)
+            
+        case .topLeft, .bottomLeft:
+            let point1 = CGPoint(x: Dimension.Tail.start,
+                                 y: tailPosition == .topLeft ? 0 : self.frame.size.height)
+            let point2 = CGPoint(x: point1.x + Dimension.Tail.width/2,
+                                 y: tailPosition == .topLeft ? -Dimension.Tail.height : point1.y + Dimension.Tail.height)
+            let point3 = CGPoint(x: point1.x + Dimension.Tail.width,
+                                 y: point1.y)
+            path.move(to: point1)
+            path.addLine(to: point2)
+            path.addLine(to: point3)
+            
+        case .topCenter, .bottomCenter:
+            let point1 = CGPoint(x: self.frame.size.width/2 - Dimension.Tail.width/2,
+                                 y: tailPosition == .topCenter ? 0 : self.frame.size.height)
+            let point2 = CGPoint(x: point1.x + Dimension.Tail.width/2,
+                                 y: tailPosition == .topCenter ? -Dimension.Tail.height : point1.y + Dimension.Tail.height)
+            let point3 = CGPoint(x: point1.x + Dimension.Tail.width,
+                                 y: point1.y)
+            path.move(to: point1)
+            path.addLine(to: point2)
+            path.addLine(to: point3)
+            
+        case .topRight, .bottomRight:
+            let point1 = CGPoint(x: self.frame.size.width - Dimension.Tail.start,
+                                 y: tailPosition == .topRight ? 0 : self.frame.size.height)
+            let point2 = CGPoint(x: point1.x - Dimension.Tail.width/2,
+                                 y: tailPosition == .topRight ? -Dimension.Tail.height : point1.y + Dimension.Tail.height)
+            let point3 = CGPoint(x: point1.x - Dimension.Tail.width,
+                                 y: point1.y)
+            path.move(to: point1)
+            path.addLine(to: point2)
+            path.addLine(to: point3)
+        }
+        path.close()
+        
+        let shape = CAShapeLayer()
+        shape.path = path.cgPath
+        shape.fillColor = color == .tooltipBG ? YDSColor.tooltipBG.cgColor : YDSColor.tooltipPoint.cgColor
+
+        self.layer.insertSublayer(shape, at: 0)
+    }
+    
+    /// 애니메이션으로 툴팁이 뷰에 보여지고 지정된 duration 동안 유지된 후 사라지게 합니다.
+    public func show() {
+        guard let superView = self.superview else { return }
+        self.addDismissView(on: superView)
+        
+        UIView.animate(withDuration: YDSAnimation.Duration.medium,
+                       animations: { self.alpha = 1.0 },
+                       completion: { [weak self] _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + (self?.duration.value ?? 1.5),
+                                          execute: {
+                self?.hide()
+            })
+        })
+    }
+    
+    /// 화면 전체 영역을 차지하고 tap을 확인할 수 있는 뷰를 추가합니다.
+    private func addDismissView(on superView: UIView) {
+        superView.addSubview(self.dismissView)
+        self.dismissView.addGestureRecognizer(self.tapRecognizer)
+        self.tapRecognizer.isEnabled = true
+    }
+    
+    /// 툴팁을 뷰에서 없애줍니다.
+    private func hide() {
+        UIView.animate(withDuration: YDSAnimation.Duration.medium,
+                       animations: { self.alpha = 0 },
+                       completion: { [weak self] _ in
+            self?.dismissView.removeFromSuperview()
+            self?.removeFromSuperview()
+            self?.tapRecognizer.isEnabled = false
+        })
+    }
+
+    /// 사용자가 뷰를 탭하면 hide()를 호출해서 툴팁을 뷰에서 없앱니다.
+    @objc private func didTapOnScreen() {
+        self.hide()
+    }
+    
+    
+    //  MARK: - 외부에서 접근할 수 없는 enum
+    
+    private enum Dimension {
+        ///  툴팁 내부에 있는 label의 마진 값입니다.
+        enum Margin {
+            static let horizontal: CGFloat = 16
+            static let vertical: CGFloat = 12
+        }
+        
+        /// 툴팁의 꼬리 너비, 높이, 시작점 값입니다.
+        enum Tail {
+            static let width: CGFloat = 16
+            static let height: CGFloat = 9
+            static let start: CGFloat = 12
+        }
+    }
+    
+    
+    //  MARK: - 외부에서 접근할 수 있는 enum
+
+    /// 툴팁의 꼬리 위치 종류입니다.
+    public enum TailPosition {
+        case left, right
+        case topLeft, bottomLeft
+        case topCenter, bottomCenter
+        case topRight, bottomRight
+    }
+    
+    /// 툴팁 색깔입니다.
+    public enum TooltipColor {
+        case tooltipBG
+        case tooltipPoint
+    }
+    
+    /// 툴팁이 유지되는 시간입니다.
+    public enum TooltipDuration {
+        case short
+        case long
+        
+        fileprivate var value: Double {
+            switch(self) {
+            case .short:
+                return 1.5
+            case .long:
+                return 3
+            }
+        }
+    }
+}

--- a/YDS/Source/Component/YDSTooltip.swift
+++ b/YDS/Source/Component/YDSTooltip.swift
@@ -11,30 +11,19 @@ final public class YDSTooltip: UIView {
     
     //  MARK: - 외부에서 지정할 수 있는 속성
     
-    /// 툴팁 내부 label의 텍스트를 설정할 때 사용합니다.
-    public var text: String? {
-        didSet {
-            label.text = text
-        }
-    }
-    
     /// 툴팁의 색깔을 설정합니다.
-    public var color: TooltipColor {
+    private var color: TooltipColor {
         didSet {
-            self.backgroundColor = color == .tooltipBG ? YDSColor.tooltipBG : YDSColor.tooltipPoint
+            self.backgroundColor = (color == .tooltipBG) ? (YDSColor.tooltipBG) : (YDSColor.tooltipPoint)
             makeTail()
         }
     }
     
     /// 툴팁의 꼬리 위치를 설정할 때 사용합니다.
-    public var tailPosition: TailPosition {
-        didSet {
-            makeTail()
-        }
-    }
+    private var tailPosition: TailPosition
     
     /// 툴팁이 뷰에 유지되는 시간을 설정할 때 사용합니다.
-    public var duration: TooltipDuration
+    private var duration: TooltipDuration
     
     
     // MARK: - 뷰
@@ -68,7 +57,7 @@ final public class YDSTooltip: UIView {
     // MARK: - 메소드
     
     public init(text: String, color: TooltipColor, tailPosition: TailPosition, duration: TooltipDuration) {
-        self.text = text
+        self.label.text = text
         self.color = color
         self.tailPosition = tailPosition
         self.duration = duration
@@ -119,19 +108,13 @@ final public class YDSTooltip: UIView {
     
     /// 툴팁의 꼬리 부분을 그립니다.
     private func makeTail() {
-        if let firstLayer = self.layer.sublayers?.first {
-            if firstLayer is CAShapeLayer {
-                firstLayer.removeFromSuperlayer()
-            }
-        }
-        
         let path = UIBezierPath()
 
         switch tailPosition {
         case .left, .right:
-            let point1 = CGPoint(x: tailPosition == .left ? 0 : self.frame.size.width,
+            let point1 = CGPoint(x: (tailPosition == .left) ? (0) : (self.frame.size.width),
                                  y: Dimension.Tail.start)
-            let point2 = CGPoint(x: tailPosition == .left ? point1.x - Dimension.Tail.height : point1.x + Dimension.Tail.height,
+            let point2 = CGPoint(x: (tailPosition == .left) ? (point1.x - Dimension.Tail.height) : (point1.x + Dimension.Tail.height),
                                  y: point1.y + Dimension.Tail.width/2)
             let point3 = CGPoint(x: point1.x,
                                  y: point1.y + Dimension.Tail.width)
@@ -141,9 +124,9 @@ final public class YDSTooltip: UIView {
             
         case .topLeft, .bottomLeft:
             let point1 = CGPoint(x: Dimension.Tail.start,
-                                 y: tailPosition == .topLeft ? 0 : self.frame.size.height)
+                                 y: (tailPosition == .topLeft) ? (0) : (self.frame.size.height))
             let point2 = CGPoint(x: point1.x + Dimension.Tail.width/2,
-                                 y: tailPosition == .topLeft ? -Dimension.Tail.height : point1.y + Dimension.Tail.height)
+                                 y: (tailPosition == .topLeft) ? (-Dimension.Tail.height) : (point1.y + Dimension.Tail.height))
             let point3 = CGPoint(x: point1.x + Dimension.Tail.width,
                                  y: point1.y)
             path.move(to: point1)
@@ -152,9 +135,9 @@ final public class YDSTooltip: UIView {
             
         case .topCenter, .bottomCenter:
             let point1 = CGPoint(x: self.frame.size.width/2 - Dimension.Tail.width/2,
-                                 y: tailPosition == .topCenter ? 0 : self.frame.size.height)
+                                 y: (tailPosition == .topCenter) ? (0) : (self.frame.size.height))
             let point2 = CGPoint(x: point1.x + Dimension.Tail.width/2,
-                                 y: tailPosition == .topCenter ? -Dimension.Tail.height : point1.y + Dimension.Tail.height)
+                                 y: (tailPosition == .topCenter) ? (-Dimension.Tail.height) : (point1.y + Dimension.Tail.height))
             let point3 = CGPoint(x: point1.x + Dimension.Tail.width,
                                  y: point1.y)
             path.move(to: point1)
@@ -163,9 +146,9 @@ final public class YDSTooltip: UIView {
             
         case .topRight, .bottomRight:
             let point1 = CGPoint(x: self.frame.size.width - Dimension.Tail.start,
-                                 y: tailPosition == .topRight ? 0 : self.frame.size.height)
+                                 y: (tailPosition == .topRight) ? (0) : (self.frame.size.height))
             let point2 = CGPoint(x: point1.x - Dimension.Tail.width/2,
-                                 y: tailPosition == .topRight ? -Dimension.Tail.height : point1.y + Dimension.Tail.height)
+                                 y: (tailPosition == .topRight) ? (-Dimension.Tail.height) : (point1.y + Dimension.Tail.height))
             let point3 = CGPoint(x: point1.x - Dimension.Tail.width,
                                  y: point1.y)
             path.move(to: point1)
@@ -176,7 +159,7 @@ final public class YDSTooltip: UIView {
         
         let shape = CAShapeLayer()
         shape.path = path.cgPath
-        shape.fillColor = color == .tooltipBG ? YDSColor.tooltipBG.cgColor : YDSColor.tooltipPoint.cgColor
+        shape.fillColor = (color == .tooltipBG) ? (YDSColor.tooltipBG.cgColor) : (YDSColor.tooltipPoint.cgColor)
 
         self.layer.insertSublayer(shape, at: 0)
     }

--- a/YDS/Source/Component/YDSTooltip.swift
+++ b/YDS/Source/Component/YDSTooltip.swift
@@ -11,19 +11,29 @@ final public class YDSTooltip: UIView {
     
     //  MARK: - 외부에서 지정할 수 있는 속성
     
-    /// 툴팁의 색깔을 설정합니다.
-    private var color: TooltipColor {
+    /// 툴팁 내부 label의 텍스트를 설정할 때 사용합니다.
+    public var text: String? {
         didSet {
-            self.backgroundColor = (color == .tooltipBG) ? (YDSColor.tooltipBG) : (YDSColor.tooltipPoint)
-            makeTail()
+            setNeedsLayout()
+        }
+    }
+    
+    /// 툴팁의 색깔을 설정합니다.
+    public var color: TooltipColor {
+        didSet {
+            setNeedsLayout()
         }
     }
     
     /// 툴팁의 꼬리 위치를 설정할 때 사용합니다.
-    private var tailPosition: TailPosition
+    public var tailPosition: TailPosition {
+        didSet {
+            setNeedsLayout()
+        }
+    }
     
     /// 툴팁이 뷰에 유지되는 시간을 설정할 때 사용합니다.
-    private var duration: TooltipDuration
+    public var duration: TooltipDuration
     
     
     // MARK: - 뷰
@@ -37,6 +47,12 @@ final public class YDSTooltip: UIView {
     }()
     
     //  MARK: - 외부에서 지정할 수 없는 속성
+    
+    private var tailLayer: CAShapeLayer = CAShapeLayer() {
+        didSet {
+            setNeedsLayout()
+        }
+    }
 
     /// 사용자의 탭을 확인하는 Recognizer
     private lazy var tapRecognizer: UITapGestureRecognizer = {
@@ -57,7 +73,7 @@ final public class YDSTooltip: UIView {
     // MARK: - 메소드
     
     public init(text: String, color: TooltipColor, tailPosition: TailPosition, duration: TooltipDuration) {
-        self.label.text = text
+        self.text = text
         self.color = color
         self.tailPosition = tailPosition
         self.duration = duration
@@ -103,11 +119,15 @@ final public class YDSTooltip: UIView {
     
     public override func layoutSubviews() {
         super.layoutSubviews()
+        label.text = text
+        backgroundColor = (color == .tooltipBG) ? (YDSColor.tooltipBG) : (YDSColor.tooltipPoint)
         makeTail()
     }
     
     /// 툴팁의 꼬리 부분을 그립니다.
     private func makeTail() {
+        tailLayer.removeFromSuperlayer()
+        
         let path = UIBezierPath()
 
         switch tailPosition {
@@ -157,11 +177,10 @@ final public class YDSTooltip: UIView {
         }
         path.close()
         
-        let shape = CAShapeLayer()
-        shape.path = path.cgPath
-        shape.fillColor = (color == .tooltipBG) ? (YDSColor.tooltipBG.cgColor) : (YDSColor.tooltipPoint.cgColor)
-
-        self.layer.insertSublayer(shape, at: 0)
+        tailLayer.path = path.cgPath
+        tailLayer.fillColor = (color == .tooltipBG) ? (YDSColor.tooltipBG.cgColor) : (YDSColor.tooltipPoint.cgColor)
+        
+        self.layer.insertSublayer(tailLayer, at: 0)
     }
     
     /// 애니메이션으로 툴팁이 뷰에 보여지고 지정된 duration 동안 유지된 후 사라지게 합니다.

--- a/YDS/Source/Component/YDSTooltip.swift
+++ b/YDS/Source/Component/YDSTooltip.swift
@@ -9,33 +9,6 @@ import UIKit
 
 final public class YDSTooltip: UIView {
     
-    //  MARK: - 외부에서 지정할 수 있는 속성
-    
-    /// 툴팁 내부 label의 텍스트를 설정할 때 사용합니다.
-    public var text: String {
-        didSet {
-            setNeedsLayout()
-        }
-    }
-    
-    /// 툴팁의 색깔을 설정합니다.
-    public var color: TooltipColor {
-        didSet {
-            setNeedsLayout()
-        }
-    }
-    
-    /// 툴팁의 꼬리 위치를 설정할 때 사용합니다.
-    public var tailPosition: TailPosition {
-        didSet {
-            setNeedsLayout()
-        }
-    }
-    
-    /// 툴팁이 뷰에 유지되는 시간을 설정할 때 사용합니다.
-    public var duration: TooltipDuration
-    
-    
     // MARK: - 뷰
     
     /// 툴팁 내부에서 텍스트를 보여주는 label
@@ -47,6 +20,30 @@ final public class YDSTooltip: UIView {
     }()
     
     //  MARK: - 외부에서 지정할 수 없는 속성
+    
+    /// 툴팁 내부 label의 텍스트를 설정할 때 사용합니다.
+    private var text: String {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+    
+    /// 툴팁의 색깔을 설정합니다.
+    private var color: TooltipColor {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+    
+    /// 툴팁의 꼬리 위치를 설정할 때 사용합니다.
+    private var tailPosition: TailPosition {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+    
+    /// 툴팁이 뷰에 유지되는 시간을 설정할 때 사용합니다.
+    private var duration: TooltipDuration
     
     /// 툴팁의 꼬리 부분을 표현하는 Layer
     private var tailLayer: CAShapeLayer = CAShapeLayer()
@@ -61,7 +58,10 @@ final public class YDSTooltip: UIView {
     
     // MARK: - 메소드
     
-    public init(text: String, color: TooltipColor, tailPosition: TailPosition, duration: TooltipDuration) {
+    public init(text: String = "",
+                color: TooltipColor = .tooltipBG,
+                tailPosition: TailPosition = .bottomRight,
+                duration: TooltipDuration = .long) {
         self.text = text
         self.color = color
         self.tailPosition = tailPosition

--- a/YDS/Source/Component/YDSTooltip.swift
+++ b/YDS/Source/Component/YDSTooltip.swift
@@ -129,9 +129,12 @@ final public class YDSTooltip: UIView {
     private func makeTail() {
         let path = UIBezierPath()
         
+        let frameWidth = frame.size.width
+        let frameHeight = frame.size.height
+        
         switch tailPosition {
         case .left, .right:
-            let point1 = CGPoint(x: (tailPosition == .left) ? (0) : (self.frame.size.width),
+            let point1 = CGPoint(x: (tailPosition == .left) ? (0) : (frameWidth),
                                  y: Dimension.Tail.start)
             let point2 = CGPoint(x: (tailPosition == .left) ? (point1.x - Dimension.Tail.height) : (point1.x + Dimension.Tail.height),
                                  y: point1.y + Dimension.Tail.width/2)
@@ -143,7 +146,7 @@ final public class YDSTooltip: UIView {
             
         case .topLeft, .bottomLeft:
             let point1 = CGPoint(x: Dimension.Tail.start,
-                                 y: (tailPosition == .topLeft) ? (0) : (self.frame.size.height))
+                                 y: (tailPosition == .topLeft) ? (0) : (frameHeight))
             let point2 = CGPoint(x: point1.x + Dimension.Tail.width/2,
                                  y: (tailPosition == .topLeft) ? (-Dimension.Tail.height) : (point1.y + Dimension.Tail.height))
             let point3 = CGPoint(x: point1.x + Dimension.Tail.width,
@@ -153,8 +156,8 @@ final public class YDSTooltip: UIView {
             path.addLine(to: point3)
             
         case .topCenter, .bottomCenter:
-            let point1 = CGPoint(x: self.frame.size.width/2 - Dimension.Tail.width/2,
-                                 y: (tailPosition == .topCenter) ? (0) : (self.frame.size.height))
+            let point1 = CGPoint(x: frameWidth/2 - Dimension.Tail.width/2,
+                                 y: (tailPosition == .topCenter) ? (0) : (frameHeight))
             let point2 = CGPoint(x: point1.x + Dimension.Tail.width/2,
                                  y: (tailPosition == .topCenter) ? (-Dimension.Tail.height) : (point1.y + Dimension.Tail.height))
             let point3 = CGPoint(x: point1.x + Dimension.Tail.width,
@@ -164,8 +167,8 @@ final public class YDSTooltip: UIView {
             path.addLine(to: point3)
             
         case .topRight, .bottomRight:
-            let point1 = CGPoint(x: self.frame.size.width - Dimension.Tail.start,
-                                 y: (tailPosition == .topRight) ? (0) : (self.frame.size.height))
+            let point1 = CGPoint(x: frameWidth - Dimension.Tail.start,
+                                 y: (tailPosition == .topRight) ? (0) : (frameHeight))
             let point2 = CGPoint(x: point1.x - Dimension.Tail.width/2,
                                  y: (tailPosition == .topRight) ? (-Dimension.Tail.height) : (point1.y + Dimension.Tail.height))
             let point3 = CGPoint(x: point1.x - Dimension.Tail.width,


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
개발한 툴팁의 코드를 수정했습니다.


## 💡 Reason
<!-- 이유까지 써주면 좋아요. -->
리뷰, 피드백을 반영해서 코드를 수정했습니다.
리베이스 풀을 잘못해서 브랜치가 꼬여서 새 브랜치에서 작업했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #109
- 피그마 : https://www.figma.com/file/0u52cd50xDQqjanMpUvUOM/%5B1.-iOS%5D-Yourssu-Design-System?node-id=4227%3A2114
- 관련 문서 : [Tooltip 문서](https://yourssu.notion.site/Tooltip-5c208827cbfc41d696bf51e11b386afc), [YDSTooltip 문서](https://yourssu.notion.site/YDSTooltip-ded15e3556c84784ae784c0c8bb5f1e6), [이전 PR](https://github.com/yourssu/YDS-iOS/pull/124)


## 📄 More File Description
- `private var tailLayer: CAShapeLayer = CAShapeLayer()`로 꼬리 부분을 그리는 layer 변수를 관리
- `setProperties()`에서 `tailLayer`를 툴팁의 첫 번째 sublayer로 삽입
- `makeTail()`에서 `tailLayer`의 path, color를 변경
- 툴팁의 속성(text, color, tailPosition)이 바뀌면 `setNeedsLayout()`을 호출 (Layout Driven UI)
- `layoutSubviews()`에서 툴팁의 text, 배경색, 꼬리를 설정
- `private lazy var touchControl: UIControl` 변수를 통해 `touchDown`일 때 툴팁이 사라지게 target 추가


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
[Layout Driven UI](https://www.sungdoo.dev/programming/layout-driven-ui/)


## 🔥 Test
<!-- Test -->
https://user-images.githubusercontent.com/39911797/162198244-1c2ed02f-9d23-4c5e-89a5-78cd266482a0.mp4
