### PR TITLE
[#136] ListItem의 title을 가져올 수 있도록 수정

### DIFF
--- a/YDS/Source/Component/List/YDSListItem.swift
+++ b/YDS/Source/Component/List/YDSListItem.swift
@@ -100,6 +100,10 @@ public class YDSListItem: UIView {
         super.layoutSubviews()
         nextIconView.isHidden = !(isShowingNextIconView ?? false)
     }
+
+    public func getTitle() -> String {
+        return self.titleLabel.text ?? ""
+    }
     
     //  MARK: - 외부에서 접근할 수 없는 enum
     

--- a/YDS/Source/Component/List/YDSListToggleItem.swift
+++ b/YDS/Source/Component/List/YDSListToggleItem.swift
@@ -71,6 +71,10 @@ public class YDSListToggleItem: UIView {
             $0.trailing.equalTo(toggle.snp.leading).offset(Dimension.Padding.gap)
         }
     }
+
+    public func getTitle() -> String {
+        return self.titleLabel.text ?? ""
+    }
     
     //  MARK: - 외부에서 접근할 수 없는 enum
     


### PR DESCRIPTION
## 📌 Summary
listItem의 title을 가져올 수 있게 메소드를 추가했습니다.



## 💡 Reason
여러개의 listItem이 있을 때 각각의 listItem을 구별하기 위한 수단으로 getTitle()을 추가했습니다.



## ✍️ Description
- 이슈 티켓 : #136 
- 피그마 : 
- 관련 문서 : 



## 📄 More File Description



## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

