### PR TITLE
[#128]-1 SetNeedsLayout Property Wrapper 추가

### DIFF
--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		C350ABE22808587600BFC9C0 /* TooltipPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C350ABE12808587600BFC9C0 /* TooltipPageViewController.swift */; };
 		C350ABE42808589200BFC9C0 /* TooltipSampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C350ABE32808589200BFC9C0 /* TooltipSampleViewController.swift */; };
 		C350ABE6280858B900BFC9C0 /* YDSTooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C350ABE5280858B900BFC9C0 /* YDSTooltip.swift */; };
+		C35F27302883F35B0061C1A0 /* SetNeedsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35F272F2883F35B0061C1A0 /* SetNeedsLayout.swift */; };
 		C37F356D27DE3475007DF859 /* YDSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F356C27DE3475007DF859 /* YDSTextView.swift */; };
 		C37F357027DE34A3007DF859 /* Optional+isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F356F27DE34A3007DF859 /* Optional+isEmpty.swift */; };
 		C37F357227DE34FE007DF859 /* TextViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F357127DE34FE007DF859 /* TextViewViewController.swift */; };
@@ -235,6 +236,7 @@
 		C350ABE12808587600BFC9C0 /* TooltipPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPageViewController.swift; sourceTree = "<group>"; };
 		C350ABE32808589200BFC9C0 /* TooltipSampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipSampleViewController.swift; sourceTree = "<group>"; };
 		C350ABE5280858B900BFC9C0 /* YDSTooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTooltip.swift; sourceTree = "<group>"; };
+		C35F272F2883F35B0061C1A0 /* SetNeedsLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNeedsLayout.swift; sourceTree = "<group>"; };
 		C37F356C27DE3475007DF859 /* YDSTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTextView.swift; sourceTree = "<group>"; };
 		C37F356F27DE34A3007DF859 /* Optional+isEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+isEmpty.swift"; sourceTree = "<group>"; };
 		C37F357127DE34FE007DF859 /* TextViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewViewController.swift; sourceTree = "<group>"; };
@@ -315,6 +317,7 @@
 				DD6C63E32642A602004CFF46 /* Foundation */,
 				DD6C63D426429C5B004CFF46 /* Atom */,
 				53EFF5CC26BA9A7B00732DCF /* Component */,
+				C35F272F2883F35B0061C1A0 /* SetNeedsLayout.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -845,6 +848,7 @@
 				5359111B269DDA31000CFFE7 /* YDSIconView.swift in Sources */,
 				533A27A026A48691009FD90A /* YDSSimpleTextFieldView.swift in Sources */,
 				53ADEA2326A1794800153636 /* YDSBundle.swift in Sources */,
+				C35F27302883F35B0061C1A0 /* SetNeedsLayout.swift in Sources */,
 				5359A5BD26BEC30300FCCECC /* YDSBottomBarController.swift in Sources */,
 				C3DCB31F2820081E00F98257 /* YDSListToggleItem.swift in Sources */,
 				53C9F70026B58EBB00EF7B86 /* YDSItemColor.swift in Sources */,

--- a/YDS/Source/SetNeedsLayout.swift
+++ b/YDS/Source/SetNeedsLayout.swift
@@ -7,35 +7,35 @@
 
 import UIKit
 
+@available(iOS, introduced: 13, deprecated: 15, message: "iOS 15 이상의 버전에서는 @Invalidating property wrapper를 사용해주세요")
 @propertyWrapper
-public final class SetNeedsLayout<Value> where Value: Equatable {
-    
-    private var stored: Value
-    
-    public static subscript<EnclosingSelf>(
-        _enclosingInstance observed: EnclosingSelf,
-        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
-        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, SetNeedsLayout>
-    ) -> Value where EnclosingSelf: UIView {
-        get {
-            return observed[keyPath: storageKeyPath].stored
-        }
-        set {
-            let oldValue = observed[keyPath: storageKeyPath].stored
-            
-            if newValue != oldValue {
-                observed[keyPath: storageKeyPath].stored = newValue
-                observed.setNeedsLayout()
-            }
-        }
-    }
-    
-    public var wrappedValue: Value {
-        get { fatalError("called wrappedValue getter") }
-        set { fatalError("called wrappedValue setter") }
-    }
+public struct SetNeedsLayout<Value: Equatable> {
+    private var value: Value
     
     public init(wrappedValue: Value) {
-        self.stored = wrappedValue
+        self.value = wrappedValue
+    }
+    
+    @available(*, unavailable, message: "이 속성에는 직접 접근 금지")
+    public var wrappedValue: Value {
+        get { fatalError("@SetNeedsLayout wrappedValue get 호출") }
+        set { fatalError("@SetNeedsLayout wrappedValue set 호출") }
+    }
+    
+    public static subscript<EnclosingSelf: UIView>(
+        _enclosingInstance observed: EnclosingSelf,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Self>
+    ) -> Value {
+        get {
+            observed[keyPath: storageKeyPath].value
+        }
+        set {
+            let oldValue = observed[keyPath: storageKeyPath].value
+            guard newValue != oldValue else { return }
+            
+            observed[keyPath: storageKeyPath].value = newValue
+            observed.setNeedsLayout()
+        }
     }
 }

--- a/YDS/Source/SetNeedsLayout.swift
+++ b/YDS/Source/SetNeedsLayout.swift
@@ -1,0 +1,41 @@
+//
+//  SetNeedsLayout.swift
+//  YDS
+//
+//  Created by Yonghyun on 2022/07/17.
+//
+
+import UIKit
+
+@propertyWrapper
+public final class SetNeedsLayout<Value> where Value: Equatable {
+    
+    private var stored: Value
+    
+    public static subscript<EnclosingSelf>(
+        _enclosingInstance observed: EnclosingSelf,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, SetNeedsLayout>
+    ) -> Value where EnclosingSelf: UIView {
+        get {
+            return observed[keyPath: storageKeyPath].stored
+        }
+        set {
+            let oldValue = observed[keyPath: storageKeyPath].stored
+            
+            if newValue != oldValue {
+                observed[keyPath: storageKeyPath].stored = newValue
+                observed.setNeedsLayout()
+            }
+        }
+    }
+    
+    public var wrappedValue: Value {
+        get { fatalError("called wrappedValue getter") }
+        set { fatalError("called wrappedValue setter") }
+    }
+    
+    public init(wrappedValue: Value) {
+        self.stored = wrappedValue
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
변수의 값이 변하면 자동으로 `setNeedsLayout()`을 호출하는 `property wrapper`를 추가했습니다.


## 💡 Reason
<!-- 이유까지 써주면 좋아요. -->
YDS를 리팩토링하며 `Layout Driven UI`를 적용하고 코드 재사용성을 높이기 위해서입니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #128 



## 📄 More File Description
- 사용하려면 `@SetNeedsLayout`를 변수 앞에 추가하면 됩니다.
- iOS 15부터 `@Invalidating` 이라는 property wrapper를 사용할 수 있는데 현재 YDS는 iOS 13부터 지원합니다.
- iOS 15로 버전을 올리게 되면 `@Invalidating`을 사용하게 `@available` 구문을 추가했습니다.
- `wrappedValue`는 쓰이지 않아서 접근을 막아놨습니다. 
- `subscript(_enclosingInstance:wrapped:storage:)` 구문을 통해 property wrapper 내부에서 외부의 `self`에 접근할 수 있습니다.


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
- [Layout Driven UI](https://www.sungdoo.dev/programming/layout-driven-ui/)
- [Swift Property Wrapper](https://docs.swift.org/swift-book/LanguageGuide/Properties.html#ID617)
- [UIView.Invalidating](https://developer.apple.com/documentation/uikit/uiview/invalidating)
- [Referencing the enclosing 'self' in a wrapper type](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md#referencing-the-enclosing-self-in-a-wrapper-type)



## 🔥 Test
<!-- Test -->
<table>
<tr>
<td> 수정 전 </td> <td> 수정 후 </td>
</tr>
<tr>
<td>

```Swift
public var subheader: String? {
    didSet {
        setNeedsLayout()
    }
}
```

 </td>
<td>

```Swift
@SetNeedsLayout public var subheader: String?
```

 </td>