### PR TITLE
[#128] - 2 Atom 리팩토링, @SetNeeds property wrapper 추가

### DIFF
--- a/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
+++ b/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
@@ -86,7 +86,8 @@ class LabelPageViewController: StoryBookViewController {
 }
 
 extension String.TypoStyle: CaseIterable {
-    public static var allCases: [String.TypoStyle] = [.title1, .title2, .title3,
+    public static var allCases: [String.TypoStyle] = [.display1, .display2,
+                                                      .title1, .title2, .title3,
                                                       .subtitle1, .subtitle2, .subtitle3,
                                                       .body1, .body2,
                                                       .button0, .button1, .button2, .button3, .button4,
@@ -108,5 +109,3 @@ extension NSParagraphStyle.LineBreakStrategy: CaseIterable {
                                                                         .hangulWordPriority,
                                                                         .standard,]
 }
-
-

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -641,18 +641,18 @@
 			isa = PBXGroup;
 			children = (
 				DD6C63D526429C6C004CFF46 /* YDSLabel.swift */,
-				53A31B5D266F500300461C29 /* YDSToggle.swift */,
-				DD48C1EB26735052004B288E /* YDSBottomSheet.swift */,
-				53EB943826A1E33A00208496 /* YDSDivider.swift */,
-				5359111A269DDA31000CFFE7 /* YDSIconView.swift */,
-				53C9F70B26B67CE900EF7B86 /* YDSCheckbox.swift */,
 				53C9F70326B5BC1A00EF7B86 /* YDSProfileImageView.swift */,
+				53C9F6FD26B58BFD00EF7B86 /* YDSBadge.swift */,
 				53C9F6FA26B5563C00EF7B86 /* YDSButton */,
+				DD9F4CAD27EB0623004F6CB5 /* YDSEmojiButton.swift */,
+				53C9F70B26B67CE900EF7B86 /* YDSCheckbox.swift */,
 				53443D9B26A7D32B0037B02E /* YDSTextField */,
 				53443D9426A5D5DA0037B02E /* YDSSearchBar.swift */,
-				53C9F6FD26B58BFD00EF7B86 /* YDSBadge.swift */,
+				DD48C1EB26735052004B288E /* YDSBottomSheet.swift */,
 				C37F356C27DE3475007DF859 /* YDSTextView.swift */,
-				DD9F4CAD27EB0623004F6CB5 /* YDSEmojiButton.swift */,
+				53EB943826A1E33A00208496 /* YDSDivider.swift */,
+				5359111A269DDA31000CFFE7 /* YDSIconView.swift */,
+				53A31B5D266F500300461C29 /* YDSToggle.swift */,
 			);
 			path = Atom;
 			sourceTree = "<group>";

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -94,7 +94,7 @@
 		C350ABE22808587600BFC9C0 /* TooltipPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C350ABE12808587600BFC9C0 /* TooltipPageViewController.swift */; };
 		C350ABE42808589200BFC9C0 /* TooltipSampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C350ABE32808589200BFC9C0 /* TooltipSampleViewController.swift */; };
 		C350ABE6280858B900BFC9C0 /* YDSTooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C350ABE5280858B900BFC9C0 /* YDSTooltip.swift */; };
-		C35F27302883F35B0061C1A0 /* SetNeedsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35F272F2883F35B0061C1A0 /* SetNeedsLayout.swift */; };
+		C35F27302883F35B0061C1A0 /* SetNeeds.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35F272F2883F35B0061C1A0 /* SetNeeds.swift */; };
 		C37F356D27DE3475007DF859 /* YDSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F356C27DE3475007DF859 /* YDSTextView.swift */; };
 		C37F357027DE34A3007DF859 /* Optional+isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F356F27DE34A3007DF859 /* Optional+isEmpty.swift */; };
 		C37F357227DE34FE007DF859 /* TextViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37F357127DE34FE007DF859 /* TextViewViewController.swift */; };
@@ -233,7 +233,7 @@
 		C350ABE12808587600BFC9C0 /* TooltipPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPageViewController.swift; sourceTree = "<group>"; };
 		C350ABE32808589200BFC9C0 /* TooltipSampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipSampleViewController.swift; sourceTree = "<group>"; };
 		C350ABE5280858B900BFC9C0 /* YDSTooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTooltip.swift; sourceTree = "<group>"; };
-		C35F272F2883F35B0061C1A0 /* SetNeedsLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNeedsLayout.swift; sourceTree = "<group>"; };
+		C35F272F2883F35B0061C1A0 /* SetNeeds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNeeds.swift; sourceTree = "<group>"; };
 		C37F356C27DE3475007DF859 /* YDSTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTextView.swift; sourceTree = "<group>"; };
 		C37F356F27DE34A3007DF859 /* Optional+isEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+isEmpty.swift"; sourceTree = "<group>"; };
 		C37F357127DE34FE007DF859 /* TextViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewViewController.swift; sourceTree = "<group>"; };
@@ -314,7 +314,7 @@
 				DD6C63E32642A602004CFF46 /* Foundation */,
 				DD6C63D426429C5B004CFF46 /* Atom */,
 				53EFF5CC26BA9A7B00732DCF /* Component */,
-				C35F272F2883F35B0061C1A0 /* SetNeedsLayout.swift */,
+				C35F272F2883F35B0061C1A0 /* SetNeeds.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -843,7 +843,7 @@
 				5359111B269DDA31000CFFE7 /* YDSIconView.swift in Sources */,
 				533A27A026A48691009FD90A /* YDSSimpleTextFieldView.swift in Sources */,
 				53ADEA2326A1794800153636 /* YDSBundle.swift in Sources */,
-				C35F27302883F35B0061C1A0 /* SetNeedsLayout.swift in Sources */,
+				C35F27302883F35B0061C1A0 /* SetNeeds.swift in Sources */,
 				5359A5BD26BEC30300FCCECC /* YDSBottomBarController.swift in Sources */,
 				C3DCB31F2820081E00F98257 /* YDSListToggleItem.swift in Sources */,
 				53C9F70026B58EBB00EF7B86 /* YDSItemColor.swift in Sources */,

--- a/YDS/Source/Atom/YDSBadge.swift
+++ b/YDS/Source/Atom/YDSBadge.swift
@@ -154,6 +154,7 @@ public class YDSBadge: UIView {
     
     public override func layoutSubviews() {
         super.layoutSubviews()
+        
         setText()
         setIcon()
         setColor()

--- a/YDS/Source/Atom/YDSBadge.swift
+++ b/YDS/Source/Atom/YDSBadge.swift
@@ -12,19 +12,13 @@ public class YDSBadge: UIView {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  뱃지의 글귀를 설정할 때 사용합니다.
-    public var text: String? = nil {
-        didSet { setText() }
-    }
+    @SetNeeds(.layout) public var text: String? = nil
     
     ///  뱃지에 들어갈 아이콘 이미지를 설정할 때 사용합니다.
-    public var icon: UIImage? = nil {
-        didSet { setIcon() }
-    }
+    @SetNeeds(.layout) public var icon: UIImage? = nil
     
     ///  뱃지의 색상을 설정할 때 사용합니다.
-    public var color: YDSItemColor = .mono {
-        didSet { setColor() }
-    }
+    @SetNeeds(.layout) public var color: YDSItemColor = .mono
     
     //  MARK: - 내부에서 사용되는 상수
     
@@ -158,4 +152,10 @@ public class YDSBadge: UIView {
         self.backgroundColor = color.backgroundColor
     }
     
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        setText()
+        setIcon()
+        setColor()
+    }
 }

--- a/YDS/Source/Atom/YDSBottomSheet.swift
+++ b/YDS/Source/Atom/YDSBottomSheet.swift
@@ -23,7 +23,7 @@ public class YDSBottomSheet: UIViewController {
         setScrollView()
     }
     
-    public func addViews(views : [UIView]) {
+    public func addViews(views: [UIView]) {
         views.forEach {
             vStack.addArrangedSubview($0)
         }
@@ -33,9 +33,9 @@ public class YDSBottomSheet: UIViewController {
         
         let contentView = UIView()
         
-        if let scrollView = panScrollable{
+        if let scrollView = panScrollable {
             view.addSubview(scrollView)
-
+            
             scrollView.snp.makeConstraints {
                 $0.edges.equalToSuperview()
             }
@@ -47,7 +47,7 @@ public class YDSBottomSheet: UIViewController {
                 $0.width.equalTo(YDSScreenSize.width)
                 $0.height.equalTo(YDSScreenSize.height)
             }
-                    
+            
             contentView.addSubview(vStack)
             
             vStack.snp.makeConstraints {
@@ -58,7 +58,7 @@ public class YDSBottomSheet: UIViewController {
     }
 }
 
-extension YDSBottomSheet : PanModalPresentable {
+extension YDSBottomSheet: PanModalPresentable {
     public var panScrollable: UIScrollView? {
         let scrollView = UIScrollView()
         scrollView.backgroundColor = YDSColor.bgNormal
@@ -89,22 +89,20 @@ extension YDSBottomSheet : PanModalPresentable {
     public var panModalBackgroundColor: UIColor {
         return YDSColor.dimNormal
     }
-
+    
     public var longFormHeight: PanModalHeight {
         let stackHeight = vStack.frame.height
         vStack.layoutIfNeeded()
         
-        var contentHeight : CGFloat = 0.0
-        let padding : CGFloat = 40.0
+        var contentHeight: CGFloat = 0.0
+        let padding: CGFloat = 40.0
         
         if stackHeight + padding < BottomSheetHeight.min {
             contentHeight = BottomSheetHeight.min
-        }
-        else if stackHeight > BottomSheetHeight.max {
+        } else if stackHeight > BottomSheetHeight.max {
             contentHeight = BottomSheetHeight.max
             panScrollable?.isScrollEnabled = true
-        }
-        else {
+        } else {
             contentHeight = stackHeight + padding
         }
         
@@ -113,6 +111,6 @@ extension YDSBottomSheet : PanModalPresentable {
 }
 
 fileprivate enum BottomSheetHeight {
-    static let min : CGFloat = 88.0
-    static let max : CGFloat = YDSScreenSize.height - 88.0
+    static let min: CGFloat = 88.0
+    static let max: CGFloat = YDSScreenSize.height - 88.0
 }

--- a/YDS/Source/Atom/YDSButton/YDSBoxButton.swift
+++ b/YDS/Source/Atom/YDSButton/YDSBoxButton.swift
@@ -17,77 +17,50 @@ public class YDSBoxButton: UIButton, YDSButtonProtocol {
     /**
      버튼을 비활성화 시킬 때 사용합니다.
      */
-    public var isDisabled: Bool = false {
-        didSet {
-            self.isEnabled = !isDisabled
-            setBoxButtonColor()
-        }
-    }
+    @SetNeeds(.layout, .display) public var isDisabled: Bool = false
     
     /**
      삭제, 탈퇴 등 파괴적인 행위를 할 때
      버튼을 빨간색으로 표시해 경고하기 위해 사용합니다.
      */
-    public var isWarned: Bool = false {
-        didSet { setBoxButtonColor() }
-    }
+    @SetNeeds(.display) public var isWarned: Bool = false
     
     /**
      버튼의 외관을 결정할 때 사용합니다.
      */
-    public var type: BoxButtonType = .filled {
-        didSet { setBoxButtonColor() }
-    }
+    @SetNeeds(.display) public var type: BoxButtonType = .filled
     
     /**
      버튼의 높이, 타이포 크기, 아이콘 크기, 패딩을 결정할 때 사용합니다.
      */
-    public var size: BoxButtonSize = .large {
-        didSet { setBoxButtonSize() }
-    }
+    @SetNeeds(.display) public var size: BoxButtonSize = .large
     
     /**
      버튼의 라운딩을 결정할 때 사용합니다.
      */
-    public var rounding: BoxButtonRounding = .r4 {
-        didSet { setBoxButtonRounding() }
-    }
+    @SetNeeds(.layout) public var rounding: BoxButtonRounding = .r4
     
     /**
      버튼의 글귀를 설정할 때 사용합니다.
      */
-    public var text: String? = nil {
-        didSet {
-            setTitle(text, for: .normal)
-            setLayoutAccordingToIcon()
-        }
-    }
+    @SetNeeds(.layout, .display) public var text: String? = nil
     
     /**
      버튼의 좌측에 들어갈 아이콘을 설정할 때 사용합니다.
      */
-    public var leftIcon: UIImage? = nil {
-        didSet { setIcon() }
-    }
+    @SetNeeds(.display) public var leftIcon: UIImage? = nil
     
     /**
      버튼의 우측에 들어갈 아이콘을 설정할 때 사용합니다.
      */
-    public var rightIcon: UIImage? = nil {
-        didSet { setIcon() }
-    }
+    @SetNeeds(.display) public var rightIcon: UIImage? = nil
     
     /**
      기본 속성을 override한 후 didSet을 설정하여
      값이 바뀔 때 ( = 버튼을 누르거나 땠을 때 ) 그에 맞춰 색을 바꿔줍니다.
      */
     public override var isHighlighted: Bool {
-        didSet {
-            if oldValue != isHighlighted {
-                setTintColorBasedOnIsHighlighted()
-                setBorderColorBasedOnIsHighlighted()
-            }
-        }
+        didSet { setNeedsDisplay() }
     }
     
     
@@ -459,7 +432,22 @@ public class YDSBoxButton: UIButton, YDSButtonProtocol {
         self.titleEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         self.contentEdgeInsets = UIEdgeInsets(top: 0, left: size.padding, bottom: 0, right: size.padding)
     }
-
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        isEnabled = !isDisabled
+        setTitle(text, for: .normal)
+        
+        setBoxButtonRounding()
+    }
+    
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        
+        setBoxButtonColor()
+        setBoxButtonSize()
+    }
 }
 
 extension UIButton {

--- a/YDS/Source/Atom/YDSButton/YDSBoxButton.swift
+++ b/YDS/Source/Atom/YDSButton/YDSBoxButton.swift
@@ -438,7 +438,6 @@ public class YDSBoxButton: UIButton, YDSButtonProtocol {
         
         isEnabled = !isDisabled
         setTitle(text, for: .normal)
-        
         setBoxButtonRounding()
     }
     

--- a/YDS/Source/Atom/YDSButton/YDSPlainButton.swift
+++ b/YDS/Source/Atom/YDSButton/YDSPlainButton.swift
@@ -17,81 +17,46 @@ public class YDSPlainButton: UIButton, YDSButtonProtocol {
     /**
      버튼을 비활성화 시킬 때 사용합니다.
      */
-    public var isDisabled: Bool = false {
-        didSet {
-            self.isEnabled = !isDisabled
-            setColor()
-        }
-    }
+    @SetNeeds(.layout, .display) public var isDisabled: Bool = false
     
     /**
      삭제, 탈퇴 등 파괴적인 행위를 할 때
      버튼을 빨간색으로 표시해 경고하기 위해 사용합니다.
      */
-    public var isWarned: Bool = false {
-        didSet { setColor() }
-    }
+    @SetNeeds(.display) public var isWarned: Bool = false
     
     
     /**
      버튼을 파란색 표시해 강조하기 위해 사용합니다.
      */
-    public var isPointed: Bool = false {
-        didSet { setColor() }
-    }
+    @SetNeeds(.display) public var isPointed: Bool = false
     
     /**
      타이포 크기, 아이콘 크기를 결정할 때 사용합니다.
      */
-    public var size: PlainButtonSize = .large {
-        didSet {
-            if size == .large {
-                setTitle(nil, for: .normal)
-            } else {
-                setTitle(text, for: .normal)
-            }
-            setSize()
-        }
-    }
+    @SetNeeds(.layout, .display) public var size: PlainButtonSize = .large
     
     /**
      버튼의 글귀를 설정할 때 사용합니다.
      */
-    public var text: String? = nil {
-        didSet {
-            if size == .large {
-                setTitle(nil, for: .normal)
-            } else {
-                setTitle(text, for: .normal)
-            }
-            setLayoutAccordingToIcon()
-        }
-    }
+    @SetNeeds(.layout, .display) public var text: String? = nil
     
     /**
      버튼의 좌측에 들어갈 아이콘을 설정할 때 사용합니다.
      */
-    public var leftIcon: UIImage? = nil {
-        didSet { setIcon() }
-    }
+    @SetNeeds(.display) public var leftIcon: UIImage? = nil
     
     /**
      버튼의 우측에 들어갈 아이콘을 설정할 때 사용합니다.
      */
-    public var rightIcon: UIImage? = nil {
-        didSet { setIcon() }
-    }
+    @SetNeeds(.display) public var rightIcon: UIImage? = nil
     
     /**
      기본 속성을 override한 후 didSet을 설정하여
      값이 바뀔 때 ( = 버튼을 누르거나 땠을 때 ) 그에 맞춰 색을 바꿔줍니다.
      */
     public override var isHighlighted: Bool {
-        didSet {
-            if oldValue != isHighlighted {
-                setTintColorBasedOnIsHighlighted()
-            }
-        }
+        didSet { setNeedsDisplay() }
     }
     
     
@@ -309,5 +274,23 @@ public class YDSPlainButton: UIButton, YDSButtonProtocol {
         self.titleEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         self.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     }
-
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        isEnabled = !isDisabled
+        
+        if size == .large {
+            setTitle(nil, for: .normal)
+        } else {
+            setTitle(text, for: .normal)
+        }
+    }
+    
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        
+        setColor()
+        setSize()
+    }
 }

--- a/YDS/Source/Atom/YDSCheckbox.swift
+++ b/YDS/Source/Atom/YDSCheckbox.swift
@@ -8,47 +8,35 @@
 import UIKit
 
 public class YDSCheckbox: UIButton {
-
+    
     //  MARK: - 외부에서 지정할 수 있는 속성
-
+    
     /**
      체크박스를 비활성화 시킬 때 사용합니다.
      */
-    public var isDisabled: Bool = false {
-        didSet {
-            self.isEnabled = !isDisabled
-            setColor()
-        }
-    }
-
+    @SetNeeds(.layout, .display) public var isDisabled: Bool = false
+    
     /**
      체크박스의 선택 여부를 나타낼 때 사용합니다.
      */
     public override var isSelected: Bool {
-        didSet { setTintColor() }
+        didSet { setNeedsDisplay() }
     }
-  
+    
     
     /**
      타이포 크기, 아이콘 크기, 아이콘과 라벨 사이 간격을 결정할 때 사용합니다.
      */
-    public var size: CheckboxSize = .large {
-        didSet { setSize() }
-    }
+    @SetNeeds(.layout, .display) public var size: CheckboxSize = .large
     
     /**
      체크박스의 글귀를 설정할 때 사용합니다.
      */
-    public var text: String? = nil {
-        didSet {
-            setTitle(text, for: .normal)
-            setLayoutAccordingToText()
-        }
-    }
+    @SetNeeds(.layout) public var text: String? = nil
     
     
     //  MARK: - 외부에서 접근할 수 있는 enum
-
+    
     /**
      체크박스의 size 종류입니다.
      각 size에 맞는 font, iconSize, spacing을 computed property로 가지고 있습니다.
@@ -90,7 +78,7 @@ public class YDSCheckbox: UIButton {
         }
     }
     
-
+    
     //  MARK: - 메소드
     
     public init() {
@@ -107,7 +95,7 @@ public class YDSCheckbox: UIButton {
         setColor()
         setSize()
     }
-
+    
     private func setColor() {
         setTitleColor()
         setTintColor()
@@ -199,5 +187,21 @@ public class YDSCheckbox: UIButton {
     private func checkboxDidTap(_ sender: UIControl) {
         self.isSelected = !isSelected
     }
-
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        self.isEnabled = !isDisabled
+        setTitle(text, for: .normal)
+        
+        setFont()
+        setLayoutAccordingToText()
+    }
+    
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        
+        setColor()
+        setIconImage()
+    }
 }

--- a/YDS/Source/Atom/YDSDivider.swift
+++ b/YDS/Source/Atom/YDSDivider.swift
@@ -70,6 +70,7 @@ public class YDSDivider: UIView {
     
     public override func layoutSubviews() {
         super.layoutSubviews()
+        
         setColor()
         setThickness()
     }

--- a/YDS/Source/Atom/YDSDivider.swift
+++ b/YDS/Source/Atom/YDSDivider.swift
@@ -28,16 +28,8 @@ public class YDSDivider: UIView {
         case vertical
     }
     
-    public var thickness: DividerThickness = .thin {
-        didSet {
-            setColor()
-            setThickness()
-        }
-    }
-    
-    private var direction: DividerDirection {
-        didSet { setThickness() }
-    }
+    @SetNeeds(.layout) public var thickness: DividerThickness = .thin
+    @SetNeeds(.layout) private var direction: DividerDirection = .horizontal
     
     public init(_ direction: DividerDirection) {
         self.direction = direction
@@ -75,5 +67,10 @@ public class YDSDivider: UIView {
             }
         }
     }
-
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        setColor()
+        setThickness()
+    }
 }

--- a/YDS/Source/Atom/YDSEmojiButton.swift
+++ b/YDS/Source/Atom/YDSEmojiButton.swift
@@ -102,8 +102,6 @@ public class YDSEmojiButton: UIControl {
         super.layoutSubviews()
         
         setCornerRadius()
-        
-        
         emojiLabel.text = emoji
         textLabel.text = text
         setEmojiButtonSize()

--- a/YDS/Source/Atom/YDSEmojiButton.swift
+++ b/YDS/Source/Atom/YDSEmojiButton.swift
@@ -14,22 +14,12 @@ public class YDSEmojiButton: UIControl {
     /**
     이모지 버튼의 이모지를 설정합니다. (ex. 😆)
      */
-    public var emoji: String? = nil {
-        didSet {
-            self.emojiLabel.text = self.emoji
-            self.setEmojiButtonSize()
-        }
-    }
+    @SetNeeds(.layout) public var emoji: String? = nil
     
     /**
     이모지 버튼 옆에 들어갈 문구나 버튼을 설정합니다. (ex. 좋아요 3 또는 3)
      */
-    public var text: String? = nil {
-        didSet {
-            self.textLabel.text = self.text
-            self.setEmojiButtonSize()
-        }
-    }
+    @SetNeeds(.layout) public var text: String? = nil
     
     /**
      버튼의 높이, 타이포 크기, 아이콘 크기, 패딩을 결정할 때 사용합니다.
@@ -47,11 +37,7 @@ public class YDSEmojiButton: UIControl {
     }
 
     public override var isSelected: Bool {
-        didSet {
-            if oldValue != isSelected {
-                setColorBasedOnIsSelected()
-            }
-        }
+        didSet { setNeedsLayout() }
     }
     
     //  MARK: - 내부에서 사용되는 상수
@@ -114,7 +100,14 @@ public class YDSEmojiButton: UIControl {
     
     override public func layoutSubviews() {
         super.layoutSubviews()
+        
         setCornerRadius()
+        
+        
+        emojiLabel.text = emoji
+        textLabel.text = text
+        setEmojiButtonSize()
+        setColorBasedOnIsSelected()
     }
 
     /**
@@ -168,4 +161,3 @@ public class YDSEmojiButton: UIControl {
         self.layer.cornerRadius = size.cornerRadius
     }
 }
-

--- a/YDS/Source/Atom/YDSIconView.swift
+++ b/YDS/Source/Atom/YDSIconView.swift
@@ -17,9 +17,7 @@ public class YDSIconView: UIImageView {
         case large = 48
     }
     
-    public var size: IconSize = .medium {
-        didSet { setIconSize() }
-    }
+    @SetNeeds(.layout) public var size: IconSize = .medium
     
     public init() {
         super.init(frame: CGRect.zero)
@@ -36,5 +34,8 @@ public class YDSIconView: UIImageView {
         }
     }
     
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        setIconSize()
+    }
 }
-

--- a/YDS/Source/Atom/YDSIconView.swift
+++ b/YDS/Source/Atom/YDSIconView.swift
@@ -36,6 +36,7 @@ public class YDSIconView: UIImageView {
     
     public override func layoutSubviews() {
         super.layoutSubviews()
+        
         setIconSize()
     }
 }

--- a/YDS/Source/Atom/YDSLabel.swift
+++ b/YDS/Source/Atom/YDSLabel.swift
@@ -8,24 +8,22 @@
 import UIKit
 
 public class YDSLabel: UILabel {
-    public var style : String.TypoStyle {
-        didSet { setAttributedText() }
-    }
+    @SetNeeds(.layout) public var style: String.TypoStyle = .body1
     
     public override var text: String? {
-        didSet { setAttributedText() }
+        didSet { layoutIfNeeded() }
     }
-
+    
     public override var textColor: UIColor! {
-        didSet { setAttributedText() }
+        didSet { setNeedsLayout() }
     }
     
     public override var lineBreakMode: NSLineBreakMode {
-        didSet { setAttributedText() }
+        didSet { setNeedsLayout() }
     }
     
     public override var lineBreakStrategy: NSParagraphStyle.LineBreakStrategy {
-        didSet { setAttributedText() }
+        didSet { setNeedsLayout() }
     }
     
     public init(style: String.TypoStyle = .body1) {
@@ -41,12 +39,16 @@ public class YDSLabel: UILabel {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setAttributedText() { 
+    private func setAttributedText() {
         guard let text = self.text else { return }
         attributedText = text.attributedString(byPreset: style,
                                                color: textColor,
                                                lineBreakMode: lineBreakMode,
                                                lineBreakStrategy: lineBreakStrategy)
     }
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        setAttributedText()
+    }
 }
-

--- a/YDS/Source/Atom/YDSLabel.swift
+++ b/YDS/Source/Atom/YDSLabel.swift
@@ -49,6 +49,7 @@ public class YDSLabel: UILabel {
     
     public override func layoutSubviews() {
         super.layoutSubviews()
+        
         setAttributedText()
     }
 }

--- a/YDS/Source/Atom/YDSProfileImageView.swift
+++ b/YDS/Source/Atom/YDSProfileImageView.swift
@@ -151,6 +151,7 @@ public class YDSProfileImageView: UIImageView {
     
     public override func layoutSubviews() {
         super.layoutSubviews()
+        
         setImageSize()
     }
 }

--- a/YDS/Source/Atom/YDSProfileImageView.swift
+++ b/YDS/Source/Atom/YDSProfileImageView.swift
@@ -9,9 +9,7 @@ import UIKit
 
 public class YDSProfileImageView: UIImageView {
     
-    public var size: ProfileImageViewSize = .small {
-        didSet { setImageSize() }
-    }
+    @SetNeeds(.layout) public var size: ProfileImageViewSize = .small
     
     public enum ProfileImageViewSize: Int {
         case extraSmall = 24
@@ -150,5 +148,9 @@ public class YDSProfileImageView: UIImageView {
     
         return path
     }
-
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        setImageSize()
+    }
 }

--- a/YDS/Source/Atom/YDSSearchBar.swift
+++ b/YDS/Source/Atom/YDSSearchBar.swift
@@ -11,21 +11,16 @@ import UIKit
  검색을 위한 TextField를 포함하고 있는 SearchBar입니다.
  */
 public class YDSSearchBar: UISearchBar {
-
+    
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    public var isDisabled: Bool = false {
-        didSet {
-            setState()
-            setPlaceholderTextColor()
-        }
-    }
+    @SetNeeds(.layout) public var isDisabled: Bool = false
     
     ///  새 값이 들어오면 setPlaceholderTextColor를 이용해
     ///  적절한 값을 가진 attributedPlaceholder로 변환합니다.
     public override var placeholder: String? {
-        didSet { setPlaceholderTextColor() }
+        didSet { setNeedsLayout() }
     }
     
     
@@ -80,7 +75,7 @@ public class YDSSearchBar: UISearchBar {
         searchTextField.clearButtonMode = .whileEditing
         searchTextField.layer.cornerRadius = YDSConstant.Rounding.r8
         searchTextField.backgroundColor = YDSColor.inputFieldElevated
-
+        
         self.setPositionAdjustment(UIOffset(horizontal: YDSSearchBar.leftMargin - YDSSearchBar.searchIconDefaultLeftMargin, vertical: 0), for: .search)
         self.setPositionAdjustment(UIOffset(horizontal: -(YDSSearchBar.rightMargin - YDSSearchBar.clearButtonDefaultRightMargin), vertical: 0), for: .clear)
         
@@ -101,7 +96,7 @@ public class YDSSearchBar: UISearchBar {
         searchTextField.textColor = YDSColor.textSecondary
         searchTextField.leftView?.tintColor = YDSColor.textSecondary
     }
-
+    
     ///  isDisabled의 값에 따라 placeholder label의 색이 달라집니다.
     private func setPlaceholderTextColor() {
         let placeholderTextColor: UIColor
@@ -120,6 +115,10 @@ public class YDSSearchBar: UISearchBar {
         }
     }
     
-    
-
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        setState()
+        setPlaceholderTextColor()
+    }
 }

--- a/YDS/Source/Atom/YDSTextField/YDSPasswordTextField/YDSPasswordTextField.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSPasswordTextField/YDSPasswordTextField.swift
@@ -226,6 +226,7 @@ public class YDSPasswordTextField: UITextField {
     
     public override func draw(_ rect: CGRect) {
         super.draw(rect)
+        
         setState()
         setPlaceholderTextColor()
         setMaskingState()

--- a/YDS/Source/Atom/YDSTextField/YDSPasswordTextField/YDSPasswordTextField.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSPasswordTextField/YDSPasswordTextField.swift
@@ -112,7 +112,7 @@ public class YDSPasswordTextField: UITextField {
             self.layer.borderColor = nil
             return
         }
-
+        
         if isNegative {
             self.isEnabled = true
             self.textColor = YDSColor.textSecondary
@@ -188,9 +188,9 @@ public class YDSPasswordTextField: UITextField {
                                              left: YDSTextField.Dimension.leftMargin,
                                              bottom: 0,
                                              right: YDSTextField.Dimension.rightMargin + self.maskingButtonWidth + YDSTextField.Dimension.subviewSpacing
-        ))
+                                            ))
     }
-
+    
     ///  editingRect의 Bound에 관한 함수입니다.
     ///  text label의 너비를 설정하기 위해 사용합니다.
     public override func editingRect(forBounds bounds: CGRect) -> CGRect {
@@ -198,7 +198,7 @@ public class YDSPasswordTextField: UITextField {
                                              left: YDSTextField.Dimension.leftMargin,
                                              bottom: 0,
                                              right: YDSTextField.Dimension.rightMargin + self.maskingButtonWidth + YDSTextField.Dimension.subviewSpacing
-        ))
+                                            ))
     }
     
     ///  이 값이 바뀔 때마다 isFirstResponder를 체크한 후
@@ -210,7 +210,7 @@ public class YDSPasswordTextField: UITextField {
             }
         }
     }
-
+    
     ///  이 메소드가 호출될 때 firstResponder가 되게 함과 동시에
     ///  기존에 필드에 입력된 값을 복사한 후, 임시 변수에 저장하고
     ///  기존에 필드에 입력된 값을 지운 후, 임시 변수에 저장한 값을 붙여넣습니다.
@@ -233,6 +233,5 @@ public class YDSPasswordTextField: UITextField {
             return false
         }
         return super.canPerformAction(action, withSender: sender)
-   }
+    }
 }
-

--- a/YDS/Source/Atom/YDSTextField/YDSPasswordTextField/YDSPasswordTextField.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSPasswordTextField/YDSPasswordTextField.swift
@@ -16,32 +16,21 @@ public class YDSPasswordTextField: UITextField {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    internal var isDisabled: Bool = false {
-        didSet {
-            setState()
-            setPlaceholderTextColor()
-        }
-    }
+    @SetNeeds(.display) internal var isDisabled: Bool = false
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
-    internal var isNegative: Bool = false {
-        didSet { setState() }
-    }
+    @SetNeeds(.display) internal var isNegative: Bool = false
     
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
-    internal var isPositive: Bool = false {
-        didSet { setState() }
-    }
+    @SetNeeds(.display) internal var isPositive: Bool = false
     
     ///  필드에 들어온 입력이 마스킹 되어있는지 여부를 나타낼 때 사용합니다.
-    internal var isMasked: Bool = true {
-        didSet { setMaskingState() }
-    }
+    @SetNeeds(.display) internal var isMasked: Bool = true
     
     ///  새 값이 들어오면 setPlaceholderTextColor를 이용해
     ///  적절한 값을 가진 attributedPlaceholder로 변환합니다.
     public override var placeholder: String? {
-        didSet { setPlaceholderTextColor() }
+        didSet { setNeedsDisplay() }
     }
     
     
@@ -143,9 +132,9 @@ public class YDSPasswordTextField: UITextField {
         self.isSecureTextEntry = isMasked
         
         if isMasked {
-            maskingButton.setImage(maskingOnIcon, for: .normal)
+            maskingButton.leftIcon = maskingOnIcon
         } else {
-            maskingButton.setImage(maskingOffIcon, for: .normal)
+            maskingButton.leftIcon = maskingOffIcon
         }
     }
     
@@ -233,5 +222,12 @@ public class YDSPasswordTextField: UITextField {
             return false
         }
         return super.canPerformAction(action, withSender: sender)
+    }
+    
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        setState()
+        setPlaceholderTextColor()
+        setMaskingState()
     }
 }

--- a/YDS/Source/Atom/YDSTextField/YDSPasswordTextField/YDSPasswordTextFieldView.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSPasswordTextField/YDSPasswordTextFieldView.swift
@@ -12,32 +12,17 @@ import UIKit
  입력 필드에 maskingButton이 붙은 TextField입니다.
  */
 public class YDSPasswordTextFieldView: UIView {
-
+    
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    public var isDisabled: Bool = false {
-        didSet {
-            setState()
-            textField.isDisabled = self.isDisabled
-        }
-    }
+    @SetNeeds(.layout) public var isDisabled: Bool = false
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
-    public var isNegative: Bool = false {
-        didSet {
-            setState()
-            textField.isNegative = self.isNegative
-        }
-    }
-
+    @SetNeeds(.layout) public var isNegative: Bool = false
+    
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
-    public var isPositive: Bool = false {
-        didSet {
-            setState()
-            textField.isPositive = self.isPositive
-        }
-    }
+    @SetNeeds(.layout) public var isPositive: Bool = false
     
     ///  필드에 들어온 입력이 마스킹 되어있는지 여부를 나타낼 때 사용합니다.
     public var isMasked: Bool = false {
@@ -89,7 +74,7 @@ public class YDSPasswordTextFieldView: UIView {
         }
     }
     
-
+    
     //  MARK: - 뷰
     
     ///  fieldLabel, textField, helperLabel을 담는 stackView입니다.
@@ -178,4 +163,12 @@ public class YDSPasswordTextFieldView: UIView {
         helperLabel.textColor = YDSColor.textTertiary
     }
     
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        setState()
+        textField.isDisabled = self.isDisabled
+        textField.isNegative = self.isNegative
+        textField.isPositive = self.isPositive
+    }
 }

--- a/YDS/Source/Atom/YDSTextField/YDSSearchTextField.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSSearchTextField.swift
@@ -15,17 +15,12 @@ public class YDSSearchTextField: UITextField {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    public var isDisabled: Bool = false {
-        didSet {
-            setState()
-            setPlaceholderTextColor()
-        }
-    }
+    @SetNeeds(.layout, .display) public var isDisabled: Bool = false
     
     ///  새 값이 들어오면 setPlaceholderTextColor를 이용해
     ///  적절한 값을 가진 attributedPlaceholder로 변환합니다.
     public override var placeholder: String? {
-        didSet { setPlaceholderTextColor() }
+        didSet { setNeedsDisplay() }
     }
     
     
@@ -156,5 +151,16 @@ public class YDSSearchTextField: UITextField {
                                              right: YDSTextField.Dimension.rightMargin + self.clearButtonWidth + YDSTextField.Dimension.subviewSpacing
         ))
     }
-
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        setState()
+    }
+    
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        
+        setPlaceholderTextColor()
+    }
 }

--- a/YDS/Source/Atom/YDSTextField/YDSSimpleTextField/YDSSimpleTextField.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSSimpleTextField/YDSSimpleTextField.swift
@@ -16,27 +16,18 @@ public class YDSSimpleTextField: UITextField {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    internal var isDisabled: Bool = false {
-        didSet {
-            setState()
-            setPlaceholderTextColor()
-        }
-    }
+    @SetNeeds(.layout, .display) internal var isDisabled: Bool = false
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
-    internal var isNegative: Bool = false {
-        didSet { setState() }
-    }
+    @SetNeeds(.layout) internal var isNegative: Bool = false
     
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
-    internal var isPositive: Bool = false {
-        didSet { setState() }
-    }
+    @SetNeeds(.layout) internal var isPositive: Bool = false
     
     ///  새 값이 들어오면 setPlaceholderTextColor를 이용해
     ///  적절한 값을 가진 attributedPlaceholder로 변환합니다.
     public override var placeholder: String? {
-        didSet { setPlaceholderTextColor() }
+        didSet { setNeedsDisplay() }
     }
     
     
@@ -154,4 +145,15 @@ public class YDSSimpleTextField: UITextField {
         ))
     }
     
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        setState()
+    }
+    
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        
+        setPlaceholderTextColor()
+    }
 }

--- a/YDS/Source/Atom/YDSTextField/YDSSimpleTextField/YDSSimpleTextField.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSSimpleTextField/YDSSimpleTextField.swift
@@ -16,13 +16,13 @@ public class YDSSimpleTextField: UITextField {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    @SetNeeds(.layout, .display) internal var isDisabled: Bool = false
+    @SetNeeds(.display) internal var isDisabled: Bool = false
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
-    @SetNeeds(.layout) internal var isNegative: Bool = false
+    @SetNeeds(.display) internal var isNegative: Bool = false
     
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
-    @SetNeeds(.layout) internal var isPositive: Bool = false
+    @SetNeeds(.display) internal var isPositive: Bool = false
     
     ///  새 값이 들어오면 setPlaceholderTextColor를 이용해
     ///  적절한 값을 가진 attributedPlaceholder로 변환합니다.
@@ -74,7 +74,7 @@ public class YDSSimpleTextField: UITextField {
             self.layer.borderColor = nil
             return
         }
-
+        
         if isNegative {
             self.isEnabled = true
             self.textColor = YDSColor.textSecondary
@@ -132,9 +132,9 @@ public class YDSSimpleTextField: UITextField {
                                              left: YDSTextField.Dimension.leftMargin,
                                              bottom: 0,
                                              right: YDSTextField.Dimension.rightMargin + self.clearButtonWidth + YDSTextField.Dimension.subviewSpacing
-        ))
+                                            ))
     }
-
+    
     ///  editingRect의 Bound에 관한 함수입니다.
     ///  text label의 너비를 설정하기 위해 사용합니다.
     public override func editingRect(forBounds bounds: CGRect) -> CGRect {
@@ -142,18 +142,13 @@ public class YDSSimpleTextField: UITextField {
                                              left: YDSTextField.Dimension.leftMargin,
                                              bottom: 0,
                                              right: YDSTextField.Dimension.rightMargin + self.clearButtonWidth + YDSTextField.Dimension.subviewSpacing
-        ))
-    }
-    
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        setState()
+                                            ))
     }
     
     public override func draw(_ rect: CGRect) {
         super.draw(rect)
         
+        setState()
         setPlaceholderTextColor()
     }
 }

--- a/YDS/Source/Atom/YDSTextField/YDSSimpleTextField/YDSSimpleTextFieldView.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSSimpleTextField/YDSSimpleTextFieldView.swift
@@ -19,7 +19,7 @@ public class YDSSimpleTextFieldView: UIView {
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
     @SetNeeds(.layout) public var isNegative: Bool = false
-
+    
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
     @SetNeeds(.layout) public var isPositive: Bool = false
     
@@ -66,7 +66,7 @@ public class YDSSimpleTextFieldView: UIView {
         }
     }
     
-
+    
     //  MARK: - 뷰
     
     ///  fieldLabel, textField, helperLabel을 담는 stackView입니다.

--- a/YDS/Source/Atom/YDSTextField/YDSSimpleTextField/YDSSimpleTextFieldView.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSSimpleTextField/YDSSimpleTextFieldView.swift
@@ -15,28 +15,13 @@ public class YDSSimpleTextFieldView: UIView {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    public var isDisabled: Bool = false {
-        didSet {
-            setState()
-            textField.isDisabled = self.isDisabled
-        }
-    }
+    @SetNeeds(.layout) public var isDisabled: Bool = false
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
-    public var isNegative: Bool = false {
-        didSet {
-            setState()
-            textField.isNegative = self.isNegative
-        }
-    }
+    @SetNeeds(.layout) public var isNegative: Bool = false
 
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
-    public var isPositive: Bool = false {
-        didSet {
-            setState()
-            textField.isPositive = self.isPositive
-        }
-    }
+    @SetNeeds(.layout) public var isPositive: Bool = false
     
     ///  필드에 입력된 텍스트입니다.
     public var text: String? {
@@ -169,5 +154,12 @@ public class YDSSimpleTextFieldView: UIView {
         helperLabel.textColor = YDSColor.textTertiary
     }
     
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        setState()
+        textField.isDisabled = isDisabled
+        textField.isNegative = isNegative
+        textField.isPositive = isPositive
+    }
 }
-

--- a/YDS/Source/Atom/YDSTextField/YDSSuffixTextField/YDSSuffixTextField.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSSuffixTextField/YDSSuffixTextField.swift
@@ -16,13 +16,13 @@ public class YDSSuffixTextField: UITextField {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    @SetNeeds(.layout, .display) internal var isDisabled: Bool = false
+    @SetNeeds(.display) internal var isDisabled: Bool = false
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
-    @SetNeeds(.layout) internal var isNegative: Bool = false
+    @SetNeeds(.display) internal var isNegative: Bool = false
     
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
-    @SetNeeds(.layout) internal var isPositive: Bool = false
+    @SetNeeds(.display) internal var isPositive: Bool = false
     
     ///  새 값이 들어오면 setPlaceholderTextColor를 이용해
     ///  적절한 값을 가진 attributedPlaceholder로 변환합니다.
@@ -99,7 +99,7 @@ public class YDSSuffixTextField: UITextField {
             self.layer.borderColor = nil
             return
         }
-
+        
         if isNegative {
             self.isEnabled = true
             self.textColor = YDSColor.textSecondary
@@ -157,9 +157,9 @@ public class YDSSuffixTextField: UITextField {
                                              left: YDSTextField.Dimension.leftMargin,
                                              bottom: 0,
                                              right: YDSTextField.Dimension.rightMargin + self.suffixLabelWidth + YDSTextField.Dimension.subviewSpacing
-        ))
+                                            ))
     }
-
+    
     ///  editingRect의 Bound에 관한 함수입니다.
     ///  text label의 너비를 설정하기 위해 사용합니다.
     public override func editingRect(forBounds bounds: CGRect) -> CGRect {
@@ -167,18 +167,13 @@ public class YDSSuffixTextField: UITextField {
                                              left: YDSTextField.Dimension.leftMargin,
                                              bottom: 0,
                                              right: YDSTextField.Dimension.rightMargin + self.suffixLabelWidth + YDSTextField.Dimension.subviewSpacing
-        ))
-    }
-    
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        setState()
+                                            ))
     }
     
     public override func draw(_ rect: CGRect) {
         super.draw(rect)
         
+        setState()
         setPlaceholderTextColor()
     }
 }

--- a/YDS/Source/Atom/YDSTextField/YDSSuffixTextField/YDSSuffixTextField.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSSuffixTextField/YDSSuffixTextField.swift
@@ -16,27 +16,18 @@ public class YDSSuffixTextField: UITextField {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    internal var isDisabled: Bool = false {
-        didSet {
-            setState()
-            setPlaceholderTextColor()
-        }
-    }
+    @SetNeeds(.layout, .display) internal var isDisabled: Bool = false
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
-    internal var isNegative: Bool = false {
-        didSet { setState() }
-    }
+    @SetNeeds(.layout) internal var isNegative: Bool = false
     
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
-    internal var isPositive: Bool = false {
-        didSet { setState() }
-    }
+    @SetNeeds(.layout) internal var isPositive: Bool = false
     
     ///  새 값이 들어오면 setPlaceholderTextColor를 이용해
     ///  적절한 값을 가진 attributedPlaceholder로 변환합니다.
     public override var placeholder: String? {
-        didSet { setPlaceholderTextColor() }
+        didSet { setNeedsDisplay() }
     }
     
     ///  필드 우측에 나타나는 suffixLabel의 텍스트입니다.
@@ -50,6 +41,8 @@ public class YDSSuffixTextField: UITextField {
             } else {
                 suffixLabel.isHidden = false
             }
+            
+            setNeedsLayout()
         }
     }
     
@@ -160,7 +153,6 @@ public class YDSSuffixTextField: UITextField {
     ///  textRect의 Bound에 관한 함수입니다.
     ///  placeholder label의 너비를 설정하기 위해 사용합니다.
     public override func textRect(forBounds bounds: CGRect) -> CGRect {
-        
         return bounds.inset(by: UIEdgeInsets(top: 0,
                                              left: YDSTextField.Dimension.leftMargin,
                                              bottom: 0,
@@ -178,5 +170,15 @@ public class YDSSuffixTextField: UITextField {
         ))
     }
     
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        setState()
+    }
+    
+    public override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        
+        setPlaceholderTextColor()
+    }
 }
-

--- a/YDS/Source/Atom/YDSTextField/YDSSuffixTextField/YDSSuffixTextFieldView.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSSuffixTextField/YDSSuffixTextFieldView.swift
@@ -19,7 +19,7 @@ public class YDSSuffixTextFieldView: UIView {
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
     @SetNeeds(.layout) public var isNegative: Bool = false
-
+    
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
     @SetNeeds(.layout) public var isPositive: Bool = false
     

--- a/YDS/Source/Atom/YDSTextField/YDSSuffixTextField/YDSSuffixTextFieldView.swift
+++ b/YDS/Source/Atom/YDSTextField/YDSSuffixTextField/YDSSuffixTextFieldView.swift
@@ -15,28 +15,13 @@ public class YDSSuffixTextFieldView: UIView {
     //  MARK: - 외부에서 지정할 수 있는 속성
     
     ///  필드를 비활성화 시킬 때 사용합니다.
-    public var isDisabled: Bool = false {
-        didSet {
-            setState()
-            textField.isDisabled = self.isDisabled
-        }
-    }
+    @SetNeeds(.layout) public var isDisabled: Bool = false
     
     ///  필드에 들어온 입력이 잘못되었음을 알릴 때 사용합니다.
-    public var isNegative: Bool = false {
-        didSet {
-            setState()
-            textField.isNegative = self.isNegative
-        }
-    }
+    @SetNeeds(.layout) public var isNegative: Bool = false
 
     ///  필드에 들어온 입력이 제대로 되었음을 알릴 때 사용합니다.
-    public var isPositive: Bool = false {
-        didSet {
-            setState()
-            textField.isPositive = self.isPositive
-        }
-    }
+    @SetNeeds(.layout) public var isPositive: Bool = false
     
     ///  필드에 입력된 텍스트입니다.
     public var text: String? {
@@ -175,5 +160,12 @@ public class YDSSuffixTextFieldView: UIView {
         helperLabel.textColor = YDSColor.textTertiary
     }
     
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        setState()
+        textField.isDisabled = self.isDisabled
+        textField.isNegative = self.isNegative
+        textField.isPositive = self.isPositive
+    }
 }
-

--- a/YDS/Source/Atom/YDSTextView.swift
+++ b/YDS/Source/Atom/YDSTextView.swift
@@ -9,43 +9,24 @@ import UIKit
 import SnapKit
 
 public class YDSTextView: UITextView {
-    public var style: String.TypoStyle {
-        didSet { setTextStyle() }
-    }
     
     public override var text: String? {
-        didSet { textDidChange() }
+        didSet { setNeedsLayout() }
     }
     
     public override var attributedText: NSAttributedString? {
-        didSet { textDidChange() }
+        didSet { setNeedsLayout() }
     }
     
     public override var textColor: UIColor! {
-        didSet { setTextStyle() }
+        didSet { setNeedsLayout() }
     }
     
-    public var lineBreakMode: NSLineBreakMode? {
-        didSet { setTextStyle() }
-    }
-    
-    public var lineBreakStrategy: NSParagraphStyle.LineBreakStrategy? {
-        didSet { setTextStyle() }
-    }
-    
-    public var placeholder: String? {
-        didSet {
-            if let placeholder = placeholder {
-                registerPlaceholder(placeholder)
-            } else {
-                removePlaceholder()
-            }
-        }
-    }
-    
-    public var placeholderColor: UIColor = YDSColor.textTertiary {
-        didSet { placeholderLabel?.textColor = placeholderColor }
-    }
+    @SetNeeds(.layout) public var style: String.TypoStyle = .body1
+    @SetNeeds(.layout) public var lineBreakMode: NSLineBreakMode? = nil
+    @SetNeeds(.layout) public var lineBreakStrategy: NSParagraphStyle.LineBreakStrategy? = nil
+    @SetNeeds(.layout) public var placeholder: String? = nil
+    @SetNeeds(.layout) public var placeholderColor: UIColor = YDSColor.textTertiary
     
     private var placeholderLabel: YDSLabel?
     private let maxHeight: CGFloat?
@@ -70,11 +51,23 @@ public class YDSTextView: UITextView {
     
     public override func layoutSubviews() {
         super.layoutSubviews()
+        
         isScrollEnabled = isOverHeight
-
+        
         if isScrollEnabled == false {
             invalidateIntrinsicContentSize()
         }
+        
+        setTextStyle()
+        textDidChange()
+        
+        if let placeholder = placeholder {
+            registerPlaceholder(placeholder)
+        } else {
+            removePlaceholder()
+        }
+        
+        placeholderLabel?.textColor = placeholderColor
     }
     
     // MARK: - Public func

--- a/YDS/Source/Atom/YDSToggle.swift
+++ b/YDS/Source/Atom/YDSToggle.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 public class YDSToggle: UISwitch {
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.onTintColor = YDSColor.buttonPoint
@@ -17,5 +16,4 @@ public class YDSToggle: UISwitch {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
 }

--- a/YDS/Source/Extension/Optional+isEmpty.swift
+++ b/YDS/Source/Extension/Optional+isEmpty.swift
@@ -5,8 +5,6 @@
 //  Created by 강민석 on 2022/03/13.
 //
 
-import Foundation
-
 extension Optional where Wrapped == NSAttributedString {
     var isEmpty: Bool {
         switch self {

--- a/YDS/Source/Foundation/YDSIcon.swift
+++ b/YDS/Source/Foundation/YDSIcon.swift
@@ -92,17 +92,17 @@ public enum YDSIcon {
 
 extension UIImage {
     fileprivate static func load(name: String) -> UIImage {
-        #if SWIFT_PACKAGE
-            guard let image = UIImage(named: name, in: .module, compatibleWith: nil) else {
-                assert(false, "\(name) 이미지 로드 실패")
-                return UIImage()
-            }
-        #else
+#if SWIFT_PACKAGE
+        guard let image = UIImage(named: name, in: .module, compatibleWith: nil) else {
+            assert(false, "\(name) 이미지 로드 실패")
+            return UIImage()
+        }
+#else
         guard let image = UIImage(named: name, in: YDSBundle.bundle, compatibleWith: nil) else {
-                assert(false, "\(name) 이미지 로드 실패")
-                return UIImage()
-            }
-        #endif
+            assert(false, "\(name) 이미지 로드 실패")
+            return UIImage()
+        }
+#endif
         image.accessibilityIdentifier = name
         return image
     }
@@ -112,7 +112,7 @@ extension UIImage {
         let image = UIGraphicsImageRenderer(size: newSize).image { _ in
             draw(in: CGRect(origin: .zero, size: newSize))
         }
-            
+        
         return image
     }
 }

--- a/YDS/Source/Foundation/YDSSemanticColor.swift
+++ b/YDS/Source/Foundation/YDSSemanticColor.swift
@@ -8,14 +8,14 @@ import UIKit
 
 public enum YDSColor {
     private static func color(light: UIColor, dark: UIColor? = nil) -> UIColor {
-       if let dark = dark  {
-           if #available(iOS 13.0, *) {
-               return UIColor { $0.userInterfaceStyle == .dark ? dark : light }
-           }
-           return light
-       } else {
-           return light
-       }
+        if let dark = dark  {
+            if #available(iOS 13.0, *) {
+                return UIColor { $0.userInterfaceStyle == .dark ? dark : light }
+            }
+            return light
+        } else {
+            return light
+        }
     }
 
     
@@ -333,8 +333,5 @@ public enum YDSColor {
 
     public static var pinkItemText: UIColor {
        return color(light: YDSBasicColor.pink600)
-    }
-       
+    }       
 }
-
-

--- a/YDS/Source/Foundation/YDSThemeColor.swift
+++ b/YDS/Source/Foundation/YDSThemeColor.swift
@@ -7,8 +7,6 @@
 
 //  브랜딩 넘어가는 기간을 버티기 위한 임시 파일
 
-import Foundation
-
 public class YDSThemeColor {
     public enum Theme {
         case ground

--- a/YDS/Source/Foundation/YDSTypoStyle.swift
+++ b/YDS/Source/Foundation/YDSTypoStyle.swift
@@ -46,8 +46,7 @@ extension String {
                 return YDSFont.title2
             case .title3:
                 return YDSFont.title3
-            
-            
+                
             case .subtitle1:
                 return YDSFont.subtitle1
             case .subtitle2:
@@ -133,5 +132,4 @@ extension String {
                                                                 lineBreakMode: lineBreakMode,
                                                                 lineBreakStrategy: lineBreakStrategy))
     }
-
 }

--- a/YDS/Source/Rule/YDSScreenSize.swift
+++ b/YDS/Source/Rule/YDSScreenSize.swift
@@ -11,6 +11,7 @@ public enum YDSScreenSize {
     public static var width: CGFloat {
         return UIScreen.main.bounds.width
     }
+    
     public static var height: CGFloat {
         return UIScreen.main.bounds.height
     }

--- a/YDS/Source/SetNeeds.swift
+++ b/YDS/Source/SetNeeds.swift
@@ -18,51 +18,6 @@ public struct SetNeedsOptions: OptionSet {
     public static let layout = SetNeedsOptions(rawValue: 1 << 1)
 }
 
-@available(iOS, introduced: 13, deprecated: 15, message: "iOS 15 이상의 버전에서는 @Invalidating property wrapper를 사용해주세요")
-<<<<<<< c6312b22973ecc8c52b2fa54dd8442d02cce3346
-@propertyWrapper
-public struct SetNeedsLayout<Value: Equatable> {
-    private var value: Value
-    
-    public init(wrappedValue: Value) {
-        self.value = wrappedValue
-    }
-    
-    @available(*, unavailable, message: "이 속성에는 직접 접근 금지")
-    public var wrappedValue: Value {
-        get { fatalError("@SetNeedsLayout wrappedValue get 호출") }
-        set { fatalError("@SetNeedsLayout wrappedValue set 호출") }
-    }
-    
-    public static subscript<EnclosingSelf: UIView>(
-        _enclosingInstance observed: EnclosingSelf,
-        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
-        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Self>
-    ) -> Value {
-        get {
-            observed[keyPath: storageKeyPath].value
-        }
-        set {
-            let oldValue = observed[keyPath: storageKeyPath].value
-            guard newValue != oldValue else { return }
-            
-            observed[keyPath: storageKeyPath].value = newValue
-            observed.setNeedsLayout()
-        }
-    }
-}
-
-//
-//  SetNeedsLayout.swift
-//  YDS
-//
-//  Created by Yonghyun on 2022/07/17.
-//
-
-import UIKit
-
-=======
->>>>>>> [#128] -1 @SetNeedsLayout 수정
 @propertyWrapper
 public struct SetNeeds<Value: Equatable> {
     private var value: Value

--- a/YDS/Source/SetNeedsLayout.swift
+++ b/YDS/Source/SetNeedsLayout.swift
@@ -39,3 +39,45 @@ public struct SetNeedsLayout<Value: Equatable> {
         }
     }
 }
+
+//
+//  SetNeedsLayout.swift
+//  YDS
+//
+//  Created by Yonghyun on 2022/07/17.
+//
+
+import UIKit
+
+@propertyWrapper
+public final class SetNeedsLayout<Value> where Value: Equatable {
+    
+    private var stored: Value
+    
+    public static subscript<EnclosingSelf>(
+        _enclosingInstance observed: EnclosingSelf,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, SetNeedsLayout>
+    ) -> Value where EnclosingSelf: UIView {
+        get {
+            return observed[keyPath: storageKeyPath].stored
+        }
+        set {
+            let oldValue = observed[keyPath: storageKeyPath].stored
+            
+            if newValue != oldValue {
+                observed[keyPath: storageKeyPath].stored = newValue
+                observed.setNeedsLayout()
+            }
+        }
+    }
+    
+    public var wrappedValue: Value {
+        get { fatalError("called wrappedValue getter") }
+        set { fatalError("called wrappedValue setter") }
+    }
+    
+    public init(wrappedValue: Value) {
+        self.stored = wrappedValue
+    }
+}

--- a/YDS/Source/SetNeedsLayout.swift
+++ b/YDS/Source/SetNeedsLayout.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 @available(iOS, introduced: 13, deprecated: 15, message: "iOS 15 이상의 버전에서는 @Invalidating property wrapper를 사용해주세요")
+<<<<<<< c6312b22973ecc8c52b2fa54dd8442d02cce3346
 @propertyWrapper
 public struct SetNeedsLayout<Value: Equatable> {
     private var value: Value
@@ -49,35 +50,36 @@ public struct SetNeedsLayout<Value: Equatable> {
 
 import UIKit
 
+=======
+>>>>>>> [#128] -1 @SetNeedsLayout 수정
 @propertyWrapper
-public final class SetNeedsLayout<Value> where Value: Equatable {
-    
-    private var stored: Value
-    
-    public static subscript<EnclosingSelf>(
-        _enclosingInstance observed: EnclosingSelf,
-        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
-        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, SetNeedsLayout>
-    ) -> Value where EnclosingSelf: UIView {
-        get {
-            return observed[keyPath: storageKeyPath].stored
-        }
-        set {
-            let oldValue = observed[keyPath: storageKeyPath].stored
-            
-            if newValue != oldValue {
-                observed[keyPath: storageKeyPath].stored = newValue
-                observed.setNeedsLayout()
-            }
-        }
-    }
-    
-    public var wrappedValue: Value {
-        get { fatalError("called wrappedValue getter") }
-        set { fatalError("called wrappedValue setter") }
-    }
+public struct SetNeedsLayout<Value: Equatable> {
+    private var value: Value
     
     public init(wrappedValue: Value) {
-        self.stored = wrappedValue
+        self.value = wrappedValue
+    }
+    
+    @available(*, unavailable, message: "이 속성에는 직접 접근 금지")
+    public var wrappedValue: Value {
+        get { fatalError("@SetNeedsLayout wrappedValue get 호출") }
+        set { fatalError("@SetNeedsLayout wrappedValue set 호출") }
+    }
+    
+    public static subscript<EnclosingSelf: UIView>(
+        _enclosingInstance observed: EnclosingSelf,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Self>
+    ) -> Value {
+        get {
+            observed[keyPath: storageKeyPath].value
+        }
+        set {
+            let oldValue = observed[keyPath: storageKeyPath].value
+            guard newValue != oldValue else { return }
+            
+            observed[keyPath: storageKeyPath].value = newValue
+            observed.setNeedsLayout()
+        }
     }
 }

--- a/YDS/Source/YDSBundle.swift
+++ b/YDS/Source/YDSBundle.swift
@@ -5,8 +5,6 @@
 //  Created by Gyuni on 2021/07/16.
 //
 
-import Foundation
-
 internal class YDSBundle {
     internal static let bundle = Bundle(for: YDSBundle.self)
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- `@SetNeeds property wrapper`를 수정했습니다.
- Layout Driven UI 방식으로 `Atom`을 리팩토링 했습니다.


## 💡 Reason
<!-- 이유까지 써주면 좋아요. -->
UI를 업데이트하는 코드를 관리하기 쉽게 하기 위해 Layout Driven UI 방식을 도입했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #128 


## 📄 More File Description

### @SetNeeds property wrapper
- `SetNeedsOptions` 타입의 상수를 인자로 받게 수정함
- `.layout`을 전달하면 `setNeedsLayout()`을 호출
- `.display`를 전달하면 `setNeedsDisplay()`를 호출
- `.layout, .display` 둘 다 전달하면 `setNeedsLayout()`, `setNeedsDisplay()` 둘 다 호출함
- 여러 개의 인자를 받았을 경우에 중복을 제거하기 위해서 `SetNeedsOptions`을 `enum` 대신 `OptionSet`로 구현
- iOS 15부터 쓸 수 있는 `@Invalidating` 방식으로 쓸 수 있게 구현

### Layout Driven UI
- UI를 업데이트하는 코드는 `layoutSubviews()` 안에 넣음
- 그런데 `layoutSubviews()` 안에는 `새로운 객체가 생성되는 코드`가 포함되면 안 됨
- 새로운 객체를 생성하여 UI를 업데이트 해야 될 때에는 `draw()` 안에 업데이트 코드를 추가


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
[Layout Driven UI](https://www.sungdoo.dev/programming/layout-driven-ui/)
[View/Layout 관련 업데이트 메소드 설명](https://zeddios.tistory.com/359)
[Update Cycle: 뷰 업데이트 메소드](https://sueaty.tistory.com/162)
[UIView.Invalidating](https://developer.apple.com/documentation/uikit/uiview/invalidating)
[OptionSet](https://developer.apple.com/documentation/swift/optionset)


## 🔥 Test
<!-- Test -->
|리팩토링 전|리팩토링 후|
|---|---|
|<img width="592" alt="Screen Shot 2022-08-07 at 16 52 26" src="https://user-images.githubusercontent.com/39911797/183281013-3d6c162d-bc9c-4808-9172-57fd7dc76f1a.png">|<img width="592" alt="Screen Shot 2022-08-07 at 16 52 06" src="https://user-images.githubusercontent.com/39911797/183281022-af79c820-f107-4440-9dc5-725148f5f873.png">|
