### PR TITLE
[#157] 폰트 lineHeight 수정

### DIFF
--- a/YDS/Source/Foundation/YDSTypoStyle.swift
+++ b/YDS/Source/Foundation/YDSTypoStyle.swift
@@ -94,8 +94,11 @@ extension String {
             case .body1, .body2:
                 return 1.5
                 
-            case .button0, .button1, .button2, .button3, .button4:
-                return 1.0
+            case .button0, .button1, .button4:
+                return 1.4
+                
+            case .button2, .button3:
+                return 1.3
                 
             case .caption0, .caption1, .caption2:
                 return 1.3


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
Button류 typo별 lineHeight를 수정했습니다.


## 💡 Reason
<!-- 이유까지 써주면 좋아요. -->
크기가 작을 때 문자열 잘림 현상이 있어서 수정된 lineHeight 수치를 반영했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #157 
- 피그마 : [링크](https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F0u52cd50xDQqjanMpUvUOM%2F%255B1.-iOS%255D-Yourssu-Design-System%3Fnode-id%3D2%253A53)
- 관련 문서 : [노션](https://www.notion.so/yourssu/IOS-Typo-Button-line-height-ca2c723db75b48e3899bbc221b0ae66a)
