### PR TITLE
[Fix/#163] YDSTextView layoutSubviews의 책임을 줄였습니다.

### DIFF
--- a/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
+++ b/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
@@ -63,9 +63,9 @@ class LabelPageViewController: StoryBookViewController {
         }
         
         addOption(description: "textColor",
-                  cases: textColors.items.map { $0.color },
-                  defaultIndex: 0) { [weak self] value in
-            self?.sampleLabel.textColor = value
+                  cases: textColors.items,
+                  defaultIndex: 0) { [weak self] colorInfo in
+            self?.sampleLabel.textColor = colorInfo.color
         }
         
         addOption(description: "lineBreakMode",
@@ -77,7 +77,7 @@ class LabelPageViewController: StoryBookViewController {
         if #available(iOS 14.0, *) {
             addOption(description: "lineBreakStrategy",
                       cases: NSParagraphStyle.LineBreakStrategy.allCases,
-                      defaultIndex: 1) { [weak self] value in
+                      defaultIndex: 2) { [weak self] value in
                 self?.sampleLabel.lineBreakStrategy = value
             }
         }
@@ -105,7 +105,8 @@ extension NSLineBreakMode: CaseIterable {
 
 @available(iOS 14.0, *)
 extension NSParagraphStyle.LineBreakStrategy: CaseIterable {
-    public static var allCases: [NSParagraphStyle.LineBreakStrategy] = [.pushOut,
+    public static var allCases: [NSParagraphStyle.LineBreakStrategy] = [[],
+                                                                        .pushOut,
                                                                         .hangulWordPriority,
                                                                         .standard,]
 }

--- a/YDS-Storybook/AtomSampleViewController/TextViewViewController.swift
+++ b/YDS-Storybook/AtomSampleViewController/TextViewViewController.swift
@@ -37,7 +37,16 @@ class TextViewViewController: StoryBookViewController {
         return button
     }()
     
-    private lazy var textView = YDSTextView(maxHeight: maxHeight)
+    private lazy var textView: YDSTextView = {
+        let textView = YDSTextView(maxHeight: maxHeight)
+        textView.delegate = self
+        textView.isScrollEnabled = false
+        textView.isEditable = true
+        textView.textContainerInset = .init(top: 12, left: 0, bottom: 12, right: 0)
+        textView.placeholder = YDSPlaceholder.comment
+        return textView
+    }()
+    
     private lazy var titleLabel: YDSLabel = {
         let label = YDSLabel(style: .subtitle2)
         label.textColor = YDSColor.textPrimary
@@ -53,14 +62,8 @@ class TextViewViewController: StoryBookViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        textView.delegate = self
-        textView.isScrollEnabled = false
-        textView.isEditable = true
-        textView.textContainerInset = .init(top: 12, left: 0, bottom: 12, right: 0)
-        textView.placeholder = YDSPlaceholder.comment
-        
         setupView()
-        stateLabel.text = textView.attributedText.isEmpty.description
+        addOptions()
     }
     
     private let maxHeight: CGFloat = 150
@@ -72,6 +75,7 @@ class TextViewViewController: StoryBookViewController {
     
     private func setViewProperty() {
         title = "TextView"
+        stateLabel.text = textView.attributedText.isEmpty.description
     }
     
     private func setViewLayouts() {
@@ -109,6 +113,34 @@ class TextViewViewController: StoryBookViewController {
             $0.top.equalTo(titleLabel.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(30)
             $0.bottom.equalToSuperview().inset(12)
+        }
+    }
+    
+    private func addOptions() {
+        addOption(description: "textColor",
+                  cases: textColors.items,
+                  defaultIndex: 0) { [weak self] colorInfo in
+            self?.textView.textColor = colorInfo.color
+        }
+        
+        addOption(description: "lineBreakMode",
+                  cases: NSLineBreakMode.allCases,
+                  defaultIndex: 0) { [weak self] value in
+            self?.textView.lineBreakMode = value
+        }
+        
+        if #available(iOS 14.0, *) {
+            addOption(description: "lineBreakStrategy",
+                      cases: NSParagraphStyle.LineBreakStrategy.allCases,
+                      defaultIndex: 2) { [weak self] value in
+                self?.textView.lineBreakStrategy = value
+            }
+        }
+        
+        addOption(description: "placeholder",
+                  cases: textColors.items,
+                  defaultIndex: 2) { [weak self] colorInfo in
+            self?.textView.placeholderColor = colorInfo.color
         }
     }
     

--- a/YDS-Storybook/Extension/Description/NSLineBreakMode+CustomStringConvertible.swift
+++ b/YDS-Storybook/Extension/Description/NSLineBreakMode+CustomStringConvertible.swift
@@ -1,0 +1,29 @@
+//
+//  NSLineBreakMode+CustomStringConvertible.swift
+//  YDS-Storybook
+//
+//  Created by 강민석 on 2022/08/18.
+//
+
+import UIKit
+
+extension NSLineBreakMode: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .byWordWrapping:
+            return "byWordWrapping"
+        case .byCharWrapping:
+            return "byCharWrapping"
+        case .byClipping:
+            return "byClipping"
+        case .byTruncatingHead:
+            return "byTruncatingHead"
+        case .byTruncatingTail:
+            return "byTruncatingTail"
+        case .byTruncatingMiddle:
+            return "byTruncatingMiddle"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/YDS-Storybook/Extension/Description/NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift
+++ b/YDS-Storybook/Extension/Description/NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift
@@ -1,0 +1,36 @@
+//
+//  NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift
+//  YDS-Storybook
+//
+//  Created by 강민석 on 2022/08/18.
+//
+
+import UIKit
+
+extension NSParagraphStyle.LineBreakStrategy: CustomStringConvertible {
+    public var description: String {
+        if #available(iOS 14.0, *) {
+            switch self {
+            case .pushOut:
+                return "pushOut"
+            case .hangulWordPriority:
+                return "hangulWordPriority"
+            case .standard:
+                return "standard"
+            case []:
+                return "none"
+            default:
+                return "unknown"
+            }
+        } else {
+            switch self {
+            case .pushOut:
+                return "pushOut"
+            case []:
+                return "none"
+            default:
+                return "unknown"
+            }
+        }
+    }
+}

--- a/YDS-Storybook/Extension/Description/UIModalPresentationStyle+CustomStringConvertible.swift
+++ b/YDS-Storybook/Extension/Description/UIModalPresentationStyle+CustomStringConvertible.swift
@@ -1,0 +1,37 @@
+//
+//  UIModalPresentationStyle+CustomStringConvertible.swift
+//  YDS-Storybook
+//
+//  Created by 강민석 on 2022/08/18.
+//
+
+import UIKit
+
+extension UIModalPresentationStyle: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .fullScreen:
+            return "fullScreen"
+        case .pageSheet:
+            return "pageSheet"
+        case .formSheet:
+            return "formSheet"
+        case .currentContext:
+            return "currentContext"
+        case .custom:
+            return "custom"
+        case .overFullScreen:
+            return "overFullScreen"
+        case .overCurrentContext:
+            return "overCurrentContext"
+        case .popover:
+            return "popover"
+        case .none:
+            return "none"
+        case .automatic:
+            return "automatic"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/YDS-Storybook/Resources/YDSColorArray.swift
+++ b/YDS-Storybook/Resources/YDSColorArray.swift
@@ -14,6 +14,12 @@ struct Color {
     let basicColorName: String
 }
 
+extension Color: CustomStringConvertible {
+    var description: String {
+        return self.name
+    }
+}
+
 struct Colors {
     let items: [Color]
     let description: String?

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -102,6 +102,9 @@
 		C3985FB827F839A700389A22 /* UIApplication+findWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3985FB727F839A700389A22 /* UIApplication+findWindow.swift */; };
 		C3A3498627E710F900005034 /* Optional+isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A3498527E710F900005034 /* Optional+isEmpty.swift */; };
 		C3A48BC3285DC90100601094 /* Parchment in Frameworks */ = {isa = PBXBuildFile; productRef = C3A48BC2285DC90100601094 /* Parchment */; };
+		C3A8033728AE23D3008E2380 /* NSLineBreakMode+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A8033628AE23D3008E2380 /* NSLineBreakMode+CustomStringConvertible.swift */; };
+		C3A8033928AE27E9008E2380 /* NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A8033828AE27E9008E2380 /* NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift */; };
+		C3A8033B28AE2A96008E2380 /* UIModalPresentationStyle+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A8033A28AE2A96008E2380 /* UIModalPresentationStyle+CustomStringConvertible.swift */; };
 		C3AFE2E2289FB1FA007D391D /* BottomSheetPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AFE2E1289FB1FA007D391D /* BottomSheetPageViewController.swift */; };
 		C3BCE664284BB3C40098E49E /* ContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BCE663284BB3C40098E49E /* ContentViewController.swift */; };
 		C3BD4E39285DBCEA00B484DC /* YDSTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BD4E38285DBCEA00B484DC /* YDSTabBarViewController.swift */; };
@@ -239,6 +242,9 @@
 		C3985FB527F832EA00389A22 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		C3985FB727F839A700389A22 /* UIApplication+findWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+findWindow.swift"; sourceTree = "<group>"; };
 		C3A3498527E710F900005034 /* Optional+isEmpty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+isEmpty.swift"; sourceTree = "<group>"; };
+		C3A8033628AE23D3008E2380 /* NSLineBreakMode+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLineBreakMode+CustomStringConvertible.swift"; sourceTree = "<group>"; };
+		C3A8033828AE27E9008E2380 /* NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift"; sourceTree = "<group>"; };
+		C3A8033A28AE2A96008E2380 /* UIModalPresentationStyle+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIModalPresentationStyle+CustomStringConvertible.swift"; sourceTree = "<group>"; };
 		C3AFE2E1289FB1FA007D391D /* BottomSheetPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheetPageViewController.swift; sourceTree = "<group>"; };
 		C3BCE663284BB3C40098E49E /* ContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewController.swift; sourceTree = "<group>"; };
 		C3BD4E38285DBCEA00B484DC /* YDSTabBarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YDSTabBarViewController.swift; sourceTree = "<group>"; };
@@ -321,6 +327,7 @@
 		532DBFD326EC7330008C2354 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				C3A8033528AE23B4008E2380 /* Description */,
 				532DBFD126EC7323008C2354 /* UITableView+Generic.swift */,
 				C3A3498527E710F900005034 /* Optional+isEmpty.swift */,
 				532DBFD426EC734F008C2354 /* UIView+AddSubviews.swift */,
@@ -568,6 +575,16 @@
 				C3985FB727F839A700389A22 /* UIApplication+findWindow.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		C3A8033528AE23B4008E2380 /* Description */ = {
+			isa = PBXGroup;
+			children = (
+				C3A8033628AE23D3008E2380 /* NSLineBreakMode+CustomStringConvertible.swift */,
+				C3A8033828AE27E9008E2380 /* NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift */,
+				C3A8033A28AE2A96008E2380 /* UIModalPresentationStyle+CustomStringConvertible.swift */,
+			);
+			path = Description;
 			sourceTree = "<group>";
 		};
 		C3DCB319282000E500F98257 /* List */ = {
@@ -896,8 +913,10 @@
 				C3BCE664284BB3C40098E49E /* ContentViewController.swift in Sources */,
 				C7F6908927DDCD17002B63C9 /* IconsPageViewController.swift in Sources */,
 				532DBFD526EC734F008C2354 /* UIView+AddSubviews.swift in Sources */,
+				C3A8033928AE27E9008E2380 /* NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift in Sources */,
 				537A0ACE26C4188C00142DCE /* DoubleTitleTopBarSampleViewController.swift in Sources */,
 				537FFAA626C3E6F800270C22 /* TopBarSampleViewController.swift in Sources */,
+				C3A8033B28AE2A96008E2380 /* UIModalPresentationStyle+CustomStringConvertible.swift in Sources */,
 				C350ABE42808589200BFC9C0 /* TooltipSampleViewController.swift in Sources */,
 				53E26E8626F0619E0036648E /* TypographiesPageViewController.swift in Sources */,
 				C3985FB627F832EA00389A22 /* SceneDelegate.swift in Sources */,
@@ -914,6 +933,7 @@
 				53E2CF4226D2A3DA000DE005 /* SearchTextFieldPageViewController.swift in Sources */,
 				53C9F70626B5BCCE00EF7B86 /* ProfileImageViewPageViewController.swift in Sources */,
 				532DBFD926EC7863008C2354 /* UIViewController+Embed.swift in Sources */,
+				C3A8033728AE23D3008E2380 /* NSLineBreakMode+CustomStringConvertible.swift in Sources */,
 				533A27B326A52E56009FD90A /* PageListViewController.swift in Sources */,
 				532DBFD226EC7323008C2354 /* UITableView+Generic.swift in Sources */,
 				5359A5C526BED19900FCCECC /* DoubleTitleTopBarPageViewController.swift in Sources */,


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->

- 굳이 layoutSubviews에서 할 필요가 없어 보이는 작업을 따로 뺐습니다.
- 추가적으로 picker item에서 NS관련객체나 custom 객체에서 이름이 불명확하거나 어렵게 되어 있는 것을 실제 케이스에 맞게CustomStringConvertible을 구현했습니다.

## 💡 Reason
<!-- 이유까지 써주면 좋아요. -->

> layoutSubviews 다이어트
- placeholder가 등록되고 변경될 때만 수정, 등록이 일어나는게 맞고, layout이 바뀔 때랑은 관련이 없다고 판단해서 해당 로직은 placehodler의 didSet으로 옮겼습니다.
- text가 변해서 TextView의 크기를 변화시킬 때는 시스템이 layoutSubviews가 불러주기 때문에, 굳이 text에 SetNeeds는 필요는 없을 듯합니다.
  - 대신 전처럼 textDidChange로 placeholder가 보여줄지 말지만 호출하도록 했습니다.

- style역시, lineBreak 등은 ContentSize를 변경할 수 있어 layout변화가 있지만, 이 역시 시스템이 자동으로 layoutSubviews를 불러주기때문에 굳이 SetNeedsLayout를 호출할 필요는 없어보입니다 
	- didSet에서 스타일 변화만 attributedText에 적용했습니다.

- textColor도 layout과 상관없을 것 같아 제거하고 , textColor만 바꾸는 함수를 만들었습니다.
- placeholderColor도 layout과 상관없을 것 같아 제거했습니다.


기존에 style 변경이 typingAttributes를 변경했었는데 이는 newly typed text에만 적용되는거라 기존의 텍스트도 업데이트되게 변경했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : Closed #163
- 피그마 : 
- 관련 문서 : 



## 📄 More File Description



## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
| Before |  After  |
|---|---|
|<img src="https://user-images.githubusercontent.com/19145853/185780750-21bd4649-6f06-459f-adbc-4f3693744387.png">|<img src="https://user-images.githubusercontent.com/19145853/185780756-801ce691-534d-4a87-a128-2d18f6ecfe1b.png">|