### PR TITLE
[#171] BottomBar의 scrollEdgeAppearance 미지원 문제 해결 및 코드 정리

### DIFF
--- a/YDS/Source/Component/YDSBottomBarController.swift
+++ b/YDS/Source/Component/YDSBottomBarController.swift
@@ -76,10 +76,15 @@ open class YDSBottomBarController: UITabBarController {
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = YDSColor.bgElevated
         appearance.shadowColor = .clear
-        appearance.stackedLayoutAppearance.normal.iconColor = YDSColor.bottomBarNormal
-        appearance.stackedLayoutAppearance.normal.titleTextAttributes = [NSAttributedString.Key.foregroundColor : YDSColor.bottomBarNormal]
-        appearance.stackedLayoutAppearance.selected.iconColor = YDSColor.bottomBarSelected
-        appearance.stackedLayoutAppearance.selected.titleTextAttributes = [NSAttributedString.Key.foregroundColor : YDSColor.bottomBarSelected]
+
+        let tabBarItemAppearance = UITabBarItemAppearance(style: .stacked)
+        tabBarItemAppearance.normal.iconColor = YDSColor.bottomBarNormal
+        tabBarItemAppearance.normal.titleTextAttributes = [.foregroundColor : YDSColor.bottomBarNormal]
+        tabBarItemAppearance.selected.iconColor = YDSColor.bottomBarSelected
+        tabBarItemAppearance.selected.titleTextAttributes = [.foregroundColor : YDSColor.bottomBarSelected]
+        appearance.stackedLayoutAppearance = tabBarItemAppearance
+        appearance.compactInlineLayoutAppearance = tabBarItemAppearance
+        appearance.inlineLayoutAppearance = tabBarItemAppearance
 
         tabBar.standardAppearance = appearance
         if #available(iOS 15.0, *) {

--- a/YDS/Source/Component/YDSBottomBarController.swift
+++ b/YDS/Source/Component/YDSBottomBarController.swift
@@ -72,13 +72,17 @@ open class YDSBottomBarController: UITabBarController {
      각종 프로퍼티를 세팅합니다.
      */
     private func setProperties() {
-        tabBar.tintColor = YDSColor.bottomBarSelected
-        tabBar.unselectedItemTintColor = YDSColor.bottomBarNormal
-        tabBar.backgroundColor = YDSColor.bgElevated
-        tabBar.isTranslucent = false
+        let appearance = UITabBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = YDSColor.bgElevated
+        appearance.shadowColor = .clear
+        appearance.stackedLayoutAppearance.normal.iconColor = YDSColor.bottomBarNormal
+        appearance.stackedLayoutAppearance.selected.iconColor = YDSColor.bottomBarSelected
 
-        UITabBar.appearance().shadowImage = UIImage()
-        UITabBar.appearance().backgroundImage = UIImage()
+        tabBar.standardAppearance = appearance
+        if #available(iOS 15.0, *) {
+            tabBar.scrollEdgeAppearance = appearance
+        }
     }
 
     /**

--- a/YDS/Source/Component/YDSBottomBarController.swift
+++ b/YDS/Source/Component/YDSBottomBarController.swift
@@ -77,7 +77,9 @@ open class YDSBottomBarController: UITabBarController {
         appearance.backgroundColor = YDSColor.bgElevated
         appearance.shadowColor = .clear
         appearance.stackedLayoutAppearance.normal.iconColor = YDSColor.bottomBarNormal
+        appearance.stackedLayoutAppearance.normal.titleTextAttributes = [NSAttributedString.Key.foregroundColor : YDSColor.bottomBarNormal]
         appearance.stackedLayoutAppearance.selected.iconColor = YDSColor.bottomBarSelected
+        appearance.stackedLayoutAppearance.selected.titleTextAttributes = [NSAttributedString.Key.foregroundColor : YDSColor.bottomBarSelected]
 
         tabBar.standardAppearance = appearance
         if #available(iOS 15.0, *) {


### PR DESCRIPTION
## 📌 Summary
BottomBar의 외관을 설정하는 과정에서 scrollEdgeAppearance를 설정해주지 않아
iOS 15 이상에서 'scrollEdge' 상황에 #000000 인 썡 검정 컬러가 나타나는 문제가 있었습니다

이 문제를 해결하고, 동시에 잘못 짜여진 코드를 수정합니다

## 💡 Reason

### 좌: 변경 전 / 우: 변경 후

<img width="1179" alt="스크린샷 2022-09-25 오후 11 43 07" src="https://user-images.githubusercontent.com/54972653/192150058-b311d818-8ab4-411b-8c77-98ce079eee86.png">



## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : https://github.com/yourssu/YDS-iOS/issues/171
- 관련 문서 : [UITabBarAppearance 문서](https://developer.apple.com/documentation/uikit/uitabbarappearance)

### 변경 전

https://user-images.githubusercontent.com/54972653/192150301-465c67de-0713-462a-b133-d1ef9bf34d0f.mp4

### 변경 후

https://user-images.githubusercontent.com/54972653/192150309-b202bbf6-d3ca-4458-af4a-d835f6aeedc8.mp4


## 📄 More File Description

iOS 13 이후부터 UIBarAppearance 라는 개념이 추가되었습니다
UINavigationBar, UITabBar 등의 외관 설정을 모아두는 객체라고 생각하면 됩니다

UIBarAppearance 객체를 통해서 설정된 상태는 기존의 방식으로 설정한 것보다 높은 우선순위를 가집니다
- eg) appearance.backgroundColor 의 우선순위가 tabBar.background 보다 높습니다

UIBarAppearance를 이용해 standardAppearance, scrollEdgeAppearance 등 상황에 따라 다양한 appearance를 설정할 수 있습니다
- scrollEdgeAppearance는 scrollView에서 보여지고 있는 내용이 edge에 있는 상황, 즉 제일 끝에 도달해 있는 상황을 뜻합니다. 위쪽 스크린 샷의 경우엔 scrollView에서 보여지고 있는 내용이 위쪽 edge에 도달해있기 때문에 scrollEdgeAppearance를 보여줘야 합니다. 그러나 기존 코드에는 scrollEdgeAppearance가 설정되어 있지 않아 기본 appearance가 보여지고 있었습니다

그래서 scrollEdgeAppearance 문제를 해결하기 위해 appearance 객체를 생성해 외관을 설정하도록 바꿨고, 새로운 방식에 맞춰 tintColor 등의 설정도 함께 바꿔주었습니다
