### PR TITLE
[#183] YDSLabel autoLayout 수정하기

### DIFF
--- a/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
+++ b/YDS-Storybook/AtomSampleViewController/LabelPageViewController.swift
@@ -39,9 +39,7 @@ class LabelPageViewController: StoryBookViewController {
 
     private func setAutolayout() {
         sampleLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.width.lessThanOrEqualToSuperview().inset(16)
-            $0.height.lessThanOrEqualToSuperview().inset(16)
+            $0.edges.equalToSuperview().inset(16)
         }
     }
 
@@ -76,7 +74,7 @@ class LabelPageViewController: StoryBookViewController {
 
         addOption(description: "alignment",
                   cases: NSTextAlignment.allCases,
-                  defaultIndex: 0) { [weak self] value in
+                  defaultIndex: 1) { [weak self] value in
             self?.sampleLabel.alignment = value
         }
 


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- YDSLable에서 짧은 단어일 때 alignment가 적용 안돼서 autoLayout 수정했습니다.
- alignment의 default option 값도 `center`로 수정하였습니다.


## 💡 Reason
<!-- 이유까지 써주면 좋아요. -->
=> 기존의 레이아웃은 텍스트가 입력된 크기만큼만(첫 번째 사진 참고) 레이아웃이 잡혀서 아무리 alignment를 수정해도 짧은 단어일 때는 정렬이 되지 않습니다. 그래서 텍스트가 보이는 뷰의 레이아웃을 다시 수정해주었습니다. (두 번째 사진 참고)

<img width="275" alt="스크린샷 2022-12-01 오후 12 10 43" src="https://user-images.githubusercontent.com/78733700/205231271-b5b2d31a-4fab-4101-84d2-b1a3555392d9.png"><img width="310" alt="스크린샷 2022-12-02 오후 3 38 42" src="https://user-images.githubusercontent.com/78733700/205231277-9b6bc7f7-1c3b-414d-8125-615d376054a2.png">



## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : https://github.com/yourssu/YDS-iOS/issues/183
- 피그마 : 
- 관련 문서 : 



## 📄 More File Description



## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

https://user-images.githubusercontent.com/78733700/205230935-31111cc9-1ac0-43eb-8a9c-042ef19fbe4b.mp4



