### PR TITLE
[#206] YDS Storybook SwiftUI용 ProfileImageView

### DIFF
--- a/YDS-Storybook/SwiftUI/Atom/ProfileImagePageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/ProfileImagePageView.swift
@@ -9,46 +9,6 @@
 import SwiftUI
 import YDS_SwiftUI
 
-fileprivate struct ProfileImageReshaper: Shape {
-    var insetRatio: CGFloat
-    var width: CGFloat
-
-    func path(in rect: CGRect) -> Path {
-        let radius = width / 2
-        let inset = radius * insetRatio
-
-        let topPoint = CGPoint(x: radius, y: 0)
-        let rightPoint = CGPoint(x: radius * 2, y: radius)
-        let bottomPoint = CGPoint(x: radius, y: radius * 2)
-        let leftPoint = CGPoint(x: 0, y: radius)
-
-        var path = Path()
-        path.move(to: topPoint)
-        path.addCurve(
-            to: rightPoint,
-            control1: CGPoint(x: radius * 2 - inset, y: 0),
-            control2: CGPoint(x: radius * 2, y: inset)
-        )
-        path.addCurve(
-            to: bottomPoint,
-            control1: CGPoint(x: radius * 2, y: radius * 2 - inset),
-            control2: CGPoint(x: radius * 2 - inset, y: radius * 2)
-        )
-        path.addCurve(
-            to: leftPoint,
-            control1: CGPoint(x: inset, y: radius * 2),
-            control2: CGPoint(x: 0, y: radius * 2 - inset)
-        )
-        path.addCurve(
-            to: topPoint,
-            control1: CGPoint(x: 0, y: inset),
-            control2: CGPoint(x: inset, y: 0)
-        )
-
-        return path
-    }
-}
-
 struct ProfileImagePageView: View {
     let title: String = "ProfileImageView"
 
@@ -56,37 +16,23 @@ struct ProfileImagePageView: View {
     @State var sizeSelectedIndex: Int = 4
     @State var image: SwiftUIImage? = YDSSwiftUIImage.images[0]
 
-    enum ProfileImageViewSize: CGFloat {
-        case extraSmall = 24
-        case small = 32
-        case medium = 48
-        case large = 72
-        case extraLarge = 96
-    }
-
     var body: some View {
         StorybookPageView(sample: {
             VStack {
                 if let image = image?.image {
-                    image
-                        .resizable()
-                        .frame(width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue,
-                            height: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue)
-                        .clipShape(ProfileImageReshaper(insetRatio: 0.2, width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue))
-                        .overlay(ProfileImageReshaper(insetRatio: 0.2, width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue)
-                            .stroke(YDSColor.borderNormal, lineWidth: YDSConstant.Border.normal))
+                    YDSProfileImageView(image: image, size: YDSProfileImageView.ProfileImageViewSize.allCases[sizeSelectedIndex])
                 }
             }
         }, options: [
             Option.optionalImage(description: "image", images: YDSSwiftUIImage.images, selectedImage: $image),
-            Option.enum(description: "size", cases: ProfileImageViewSize.allCases, selectedIndex: $sizeSelectedIndex)
+            Option.enum(description: "size", cases: YDSProfileImageView.ProfileImageViewSize.allCases, selectedIndex: $sizeSelectedIndex),
         ])
         .navigationTitle(title)
     }
 }
 
-extension ProfileImagePageView.ProfileImageViewSize: CaseIterable {
-    static var allCases: [ProfileImagePageView.ProfileImageViewSize] =
+extension YDSProfileImageView.ProfileImageViewSize: CaseIterable {
+    public static var allCases: [YDSProfileImageView.ProfileImageViewSize] =
     [.extraSmall, .small, .medium, .large, .extraLarge]
 }
 

--- a/YDS-Storybook/SwiftUI/Atom/ProfileImagePageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/ProfileImagePageView.swift
@@ -9,19 +9,19 @@
 import SwiftUI
 import YDS_SwiftUI
 
-struct SquircleShape: Shape {
+fileprivate struct ProfileImageReshaper: Shape {
     var insetRatio: CGFloat
     var width: CGFloat
-    
+
     func path(in rect: CGRect) -> Path {
         let radius = width / 2
         let inset = radius * insetRatio
-        
+
         let topPoint = CGPoint(x: radius, y: 0)
         let rightPoint = CGPoint(x: radius * 2, y: radius)
         let bottomPoint = CGPoint(x: radius, y: radius * 2)
         let leftPoint = CGPoint(x: 0, y: radius)
-        
+
         var path = Path()
         path.move(to: topPoint)
         path.addCurve(
@@ -44,7 +44,7 @@ struct SquircleShape: Shape {
             control1: CGPoint(x: 0, y: inset),
             control2: CGPoint(x: inset, y: 0)
         )
-        
+
         return path
     }
 }
@@ -72,8 +72,8 @@ struct ProfileImagePageView: View {
                         .resizable()
                         .frame(width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue,
                             height: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue)
-                        .clipShape(SquircleShape(insetRatio: 0.2, width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue))
-                        .overlay(SquircleShape(insetRatio: 0.2, width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue)
+                        .clipShape(ProfileImageReshaper(insetRatio: 0.2, width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue))
+                        .overlay(ProfileImageReshaper(insetRatio: 0.2, width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue)
                             .stroke(YDSColor.borderNormal, lineWidth: YDSConstant.Border.normal))
                 }
             }

--- a/YDS-Storybook/SwiftUI/Atom/ProfileImagePageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/ProfileImagePageView.swift
@@ -19,13 +19,21 @@ struct ProfileImagePageView: View {
     var body: some View {
         StorybookPageView(sample: {
             VStack {
-                if let image = image?.image {
-                    YDSProfileImageView(image: image, size: YDSProfileImageView.ProfileImageViewSize.allCases[sizeSelectedIndex])
+                image?.image.map {
+                    YDSProfileImageView(
+                        image: $0,
+                        size: YDSProfileImageView.ProfileImageViewSize.allCases[sizeSelectedIndex])
                 }
             }
         }, options: [
-            Option.optionalImage(description: "image", images: YDSSwiftUIImage.images, selectedImage: $image),
-            Option.enum(description: "size", cases: YDSProfileImageView.ProfileImageViewSize.allCases, selectedIndex: $sizeSelectedIndex),
+            Option.optionalImage(
+                description: "image",
+                images: YDSSwiftUIImage.images,
+                selectedImage: $image),
+            Option.enum(
+                description: "size",
+                cases: YDSProfileImageView.ProfileImageViewSize.allCases,
+                selectedIndex: $sizeSelectedIndex)
         ])
         .navigationTitle(title)
     }

--- a/YDS-Storybook/SwiftUI/Atom/ProfileImagePageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/ProfileImagePageView.swift
@@ -1,0 +1,97 @@
+//
+//  ProfileImageView.swift
+//  YDS-Storybook
+//
+//  Created by 심상현 on 2023/09/04.
+//
+// 
+
+import SwiftUI
+import YDS_SwiftUI
+
+struct SquircleShape: Shape {
+    var insetRatio: CGFloat
+    var width: CGFloat
+    
+    func path(in rect: CGRect) -> Path {
+        let radius = width / 2
+        let inset = radius * insetRatio
+        
+        let topPoint = CGPoint(x: radius, y: 0)
+        let rightPoint = CGPoint(x: radius * 2, y: radius)
+        let bottomPoint = CGPoint(x: radius, y: radius * 2)
+        let leftPoint = CGPoint(x: 0, y: radius)
+        
+        var path = Path()
+        path.move(to: topPoint)
+        path.addCurve(
+            to: rightPoint,
+            control1: CGPoint(x: radius * 2 - inset, y: 0),
+            control2: CGPoint(x: radius * 2, y: inset)
+        )
+        path.addCurve(
+            to: bottomPoint,
+            control1: CGPoint(x: radius * 2, y: radius * 2 - inset),
+            control2: CGPoint(x: radius * 2 - inset, y: radius * 2)
+        )
+        path.addCurve(
+            to: leftPoint,
+            control1: CGPoint(x: inset, y: radius * 2),
+            control2: CGPoint(x: 0, y: radius * 2 - inset)
+        )
+        path.addCurve(
+            to: topPoint,
+            control1: CGPoint(x: 0, y: inset),
+            control2: CGPoint(x: inset, y: 0)
+        )
+        
+        return path
+    }
+}
+
+struct ProfileImagePageView: View {
+    let title: String = "ProfileImageView"
+
+    @State var imageSelectedIndex: Int = 0
+    @State var sizeSelectedIndex: Int = 4
+    @State var image: SwiftUIImage? = YDSSwiftUIImage.images[0]
+
+    enum ProfileImageViewSize: CGFloat {
+        case extraSmall = 24
+        case small = 32
+        case medium = 48
+        case large = 72
+        case extraLarge = 96
+    }
+
+    var body: some View {
+        StorybookPageView(sample: {
+            VStack {
+                if let image = image?.image {
+                    image
+                        .resizable()
+                        .frame(width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue,
+                            height: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue)
+                        .clipShape(SquircleShape(insetRatio: 0.2, width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue))
+                        .overlay(SquircleShape(insetRatio: 0.2, width: ProfileImageViewSize.allCases[sizeSelectedIndex].rawValue)
+                            .stroke(YDSColor.borderNormal, lineWidth: YDSConstant.Border.normal))
+                }
+            }
+        }, options: [
+            Option.optionalImage(description: "image", images: YDSSwiftUIImage.images, selectedImage: $image),
+            Option.enum(description: "size", cases: ProfileImageViewSize.allCases, selectedIndex: $sizeSelectedIndex)
+        ])
+        .navigationTitle(title)
+    }
+}
+
+extension ProfileImagePageView.ProfileImageViewSize: CaseIterable {
+    static var allCases: [ProfileImagePageView.ProfileImageViewSize] =
+    [.extraSmall, .small, .medium, .large, .extraLarge]
+}
+
+struct ProfileImagePageView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileImagePageView()
+    }
+}

--- a/YDS-Storybook/SwiftUI/PageListView.swift
+++ b/YDS-Storybook/SwiftUI/PageListView.swift
@@ -47,8 +47,8 @@ struct PageListView: View {
 
     @ViewBuilder
     var atomPages: some View {
-        PageView(title: "Empty") {
-            EmptyView()
+        PageView(title: "ProfileImageView") {
+            ProfileImagePageView()
         }
     }
 

--- a/YDS-Storybook/SwiftUI/Resources/SwiftUIYDSImageArray.swift
+++ b/YDS-Storybook/SwiftUI/Resources/SwiftUIYDSImageArray.swift
@@ -1,0 +1,48 @@
+//
+//  SwiftUIYDSImageArray.swift
+//  YDS-Storybook
+//
+//  Created by 심상현 on 2023/09/04.
+//
+
+import SwiftUI
+import YDS_SwiftUI
+
+struct SwiftUIImage {
+    let image: Image?
+    let name: String
+}
+
+extension SwiftUIImage: CustomStringConvertible {
+    var description: String {
+        return self.name
+    }
+}
+
+extension SwiftUIImage: Identifiable {
+    var id: String {
+        return self.name
+    }
+}
+
+struct SwiftUIImages {
+    let items: [SwiftUIImage]
+    let description: String?
+}
+
+extension SwiftUIImages: Identifiable {
+    var id: UUID {
+        UUID()
+    }
+}
+
+struct YDSSwiftUIImage {
+    static let images = [
+        SwiftUIImage(image: Image("profileImageSample1"), name: "profileImageOldang"),
+        SwiftUIImage(image: Image("profileImageSample2"), name: "profileImageBunny"),
+        SwiftUIImage(image: Image("profileImageSample3"), name: "profileImageHox"),
+        SwiftUIImage(image: Image("profileImageSample4"), name: "profileImageWind"),
+        SwiftUIImage(image: Image("profileImageSample5"), name: "profileImageBBuChoung"),
+        SwiftUIImage(image: Image("profileImageSample6"), name: "profileImageDino")
+    ]
+}

--- a/YDS-Storybook/SwiftUI/Resources/YDSProfileImageView.swift
+++ b/YDS-Storybook/SwiftUI/Resources/YDSProfileImageView.swift
@@ -71,23 +71,33 @@ public struct YDSProfileImageView: View {
         }
     }
 
+    /// 컨텐츠 모드 설정
+    public enum ProfileImageContentMode {
+        case fit
+        case fill
+    }
+
     private let image: Image?
     private let size: ProfileImageViewSize
     private var color = YDSColor.borderNormal
     private var width = YDSConstant.Border.normal
+    private let contentMode: ProfileImageContentMode
 
     /**
-     프로필 이미지와 크기를 설정하는 초기화 함수
-     
+     프로필 이미지와 크기를 설정
      - Parameters:
         - image: 표시할 이미지
-        - size: 이미지의 크기. `ProfileImageViewSize` enum 값을 사용
-     
+        - size: 이미지의 크기. `ProfileImageViewSize` enum 값을 사용.
+     default value는 `.small`.
+        - contentMode: 해당 프레임에 이미지 비율을 어떻게 넣을 지 결정.
+     `ProfileImageContentMode` enum 값을 사용.
+     default value는 `.fit`.
      - Returns: YDSProfileImageView 인스턴스
      */
-    public init(image: Image, size: ProfileImageViewSize?) {
+    public init(image: Image, size: ProfileImageViewSize = .small, contentMode: ProfileImageContentMode = .fit) {
         self.image = image
-        self.size = size ?? .small
+        self.size = size
+        self.contentMode = contentMode
     }
 
     /**
@@ -119,6 +129,7 @@ public struct YDSProfileImageView: View {
         if let image = image {
             image
                 .resizable()
+                .aspectRatio(contentMode: contentMode == .fit ? .fit : .fill)
                 .frame(width: size.size, height: size.size)
                 .clipShape(ProfileImageReshaper(insetRatio: 0.2, width: size.size))
                 .overlay(ProfileImageReshaper(insetRatio: 0.2, width: size.size)

--- a/YDS-Storybook/SwiftUI/Resources/YDSProfileImageView.swift
+++ b/YDS-Storybook/SwiftUI/Resources/YDSProfileImageView.swift
@@ -122,7 +122,7 @@ public struct YDSProfileImageView: View {
      - Returns: nil
      */
     init?() {
-        fatalError("initialize")
+        fatalError("Initialization failed: YDSProfileImageView requires an Image and a size to be initialized.")
     }
 
     public var body: some View {

--- a/YDS-Storybook/SwiftUI/Resources/YDSProfileImageView.swift
+++ b/YDS-Storybook/SwiftUI/Resources/YDSProfileImageView.swift
@@ -1,0 +1,122 @@
+//
+//  YDSProfileImageView.swift
+//  YDS-SwiftUI
+//
+//  Created by 심상현 on 2023/09/08.
+//
+
+import SwiftUI
+import YDS_Essential
+
+/// 이미지를 ProfileImage 형태로 변환하는 Shape
+private struct ProfileImageReshaper: Shape {
+    var insetRatio: CGFloat // 내부 여백 비율
+    var width: CGFloat // 이미지 너비
+
+    func path(in rect: CGRect) -> Path {
+        let radius = width / 2
+        let inset = radius * insetRatio
+
+        let topPoint = CGPoint(x: radius, y: 0)
+        let rightPoint = CGPoint(x: radius * 2, y: radius)
+        let bottomPoint = CGPoint(x: radius, y: radius * 2)
+        let leftPoint = CGPoint(x: 0, y: radius)
+
+        var path = Path()
+        path.move(to: topPoint)
+        path.addCurve(
+            to: rightPoint,
+            control1: CGPoint(x: radius * 2 - inset, y: 0),
+            control2: CGPoint(x: radius * 2, y: inset)
+        )
+        path.addCurve(
+            to: bottomPoint,
+            control1: CGPoint(x: radius * 2, y: radius * 2 - inset),
+            control2: CGPoint(x: radius * 2 - inset, y: radius * 2)
+        )
+        path.addCurve(
+            to: leftPoint,
+            control1: CGPoint(x: inset, y: radius * 2),
+            control2: CGPoint(x: 0, y: radius * 2 - inset)
+        )
+        path.addCurve(
+            to: topPoint,
+            control1: CGPoint(x: 0, y: inset),
+            control2: CGPoint(x: inset, y: 0)
+        )
+
+        return path
+    }
+}
+
+public struct YDSProfileImageView: View {
+    /// 프로필 이미지 크기
+    public enum ProfileImageViewSize: CGFloat {
+        case extraSmall = 24
+        case small = 32
+        case medium = 48
+        case large = 72
+        case extraLarge = 96
+    }
+
+    private let image: Image?
+    private let size: ProfileImageViewSize
+    private var color = YDSColor.borderNormal
+    private var width = YDSConstant.Border.normal
+
+    /**
+     프로필 이미지와 크기를 설정하는 초기화 함수
+     
+     - Parameters:
+        - image: 표시할 이미지
+        - size: 이미지의 크기. `ProfileImageViewSize` enum 값을 사용
+     
+     - Returns: YDSProfileImageView 인스턴스
+     */
+    public init(image: Image, size: ProfileImageViewSize?) {
+        self.image = image
+        self.size = size ?? .small
+    }
+
+    /**
+     테두리 색상과 두께를 설정
+     
+     - Parameters:
+        - color: 테두리 색상
+        - width: 테두리 두께
+     
+     - Returns: 테두리가 설정된 YDSProfileImageView 인스턴스
+     */
+    public func border(color: Color, width: CGFloat) -> YDSProfileImageView {
+        var view = self
+        view.color = color
+        view.width = width
+        return view
+    }
+
+    /**
+     초기화 실패 시 호출되는 이니셜라이저
+     
+     - Returns: nil
+     */
+    init?() {
+        fatalError("initialize")
+    }
+
+    public var body: some View {
+        if let image = image {
+            image
+                .resizable()
+                .frame(width: size.rawValue, height: size.rawValue)
+                .clipShape(ProfileImageReshaper(insetRatio: 0.2, width: size.rawValue))
+                .overlay(ProfileImageReshaper(insetRatio: 0.2, width: size.rawValue)
+                    .stroke(color, lineWidth: width))
+        }
+    }
+}
+
+struct YDSProfileImageView_Previews: PreviewProvider {
+    static var previews: some View {
+        YDSProfileImageView(image: Image(""), size: YDSProfileImageView.ProfileImageViewSize.large)
+    }
+}

--- a/YDS-Storybook/SwiftUI/Resources/YDSProfileImageView.swift
+++ b/YDS-Storybook/SwiftUI/Resources/YDSProfileImageView.swift
@@ -51,12 +51,24 @@ private struct ProfileImageReshaper: Shape {
 
 public struct YDSProfileImageView: View {
     /// 프로필 이미지 크기
-    public enum ProfileImageViewSize: CGFloat {
-        case extraSmall = 24
-        case small = 32
-        case medium = 48
-        case large = 72
-        case extraLarge = 96
+    public enum ProfileImageViewSize {
+        case extraSmall
+        case small
+        case medium
+        case large
+        case extraLarge
+        case custom(CGFloat)
+
+        fileprivate var size: CGFloat {
+            switch self {
+            case .extraSmall: return 24
+            case .small: return 32
+            case .medium: return 48
+            case .large: return 72
+            case .extraLarge: return 96
+            case let .custom(value): return value
+            }
+        }
     }
 
     private let image: Image?
@@ -107,9 +119,9 @@ public struct YDSProfileImageView: View {
         if let image = image {
             image
                 .resizable()
-                .frame(width: size.rawValue, height: size.rawValue)
-                .clipShape(ProfileImageReshaper(insetRatio: 0.2, width: size.rawValue))
-                .overlay(ProfileImageReshaper(insetRatio: 0.2, width: size.rawValue)
+                .frame(width: size.size, height: size.size)
+                .clipShape(ProfileImageReshaper(insetRatio: 0.2, width: size.size))
+                .overlay(ProfileImageReshaper(insetRatio: 0.2, width: size.size)
                     .stroke(color, lineWidth: width))
         }
     }

--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/Base/Option.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/Base/Option.swift
@@ -9,11 +9,12 @@ import SwiftUI
 
 enum Option: View {
     case bool(description: String?, isOn: Binding<Bool>)
-    case `enum`(description:String?, cases:[Any], selectedIndex:Binding<Int>)
+    case `enum`(description: String?, cases: [Any], selectedIndex: Binding<Int>)
     case int(description: String?, value: Binding<Int>)
     case optionalString(description: String?, text: Binding<String?>)
     case optionalIcon(description: String?, icons: [SwiftUIIcon], selectedIcon: Binding<SwiftUIIcon?>)
-    
+    case optionalImage(description: String?, images: [SwiftUIImage], selectedImage: Binding<SwiftUIImage?>)
+
     @ViewBuilder
     var body: some View {
         switch self {
@@ -27,6 +28,8 @@ enum Option: View {
             OptionalStringOptionView(description: description, text: text)
         case .optionalIcon(let description, let icons, let selectedIcon):
             OptionalIconOptionView(description: description, icons: icons, selectedIcon: selectedIcon)
+        case .optionalImage(let description, let images, let selectedImage):
+            OptionalImageOptionView(description: description, images: images, selectedImage: selectedImage)
         }
     }
 }

--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalIconOptionView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalIconOptionView.swift
@@ -28,10 +28,10 @@ struct OptionalIconOptionView: View {
     
     private let description: String?
     private let icons: [SwiftUIIcon]
-    
+
     @State private var placeholderIndex: Int
     @State private var isPresentPicker = false
-    
+
     init(description: String?, icons: [SwiftUIIcon], selectedIcon: Binding<SwiftUIIcon?>) {
         self.description = description
         self.icons = icons

--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalImageOptionView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalImageOptionView.swift
@@ -1,0 +1,84 @@
+//
+//  OptionalImageOptionView.swift
+//  YDS-Storybook
+//
+//  Created by 심상현 on 2023/09/04.
+//
+// swiftlint:disable line_length
+
+import SwiftUI
+import YDS_SwiftUI
+
+
+struct OptionalImageOptionView: View {
+    private enum Dimension {
+        enum Spacing {
+            static let vstack: CGFloat = 8
+            static let textSpacing: CGFloat = 4
+        }
+        
+        enum Padding {
+            static let button: CGFloat = 16
+        }
+        
+        enum Rectangle {
+            static let cornerRadius: CGFloat = 8
+        }
+    }
+    
+    @Binding private var selectedImage: SwiftUIImage?
+    
+    private let description: String?
+    private let images: [SwiftUIImage]
+    
+    @State private var placeholderIndex: Int
+    @State private var isPresentPicker = false
+    
+    init(description: String?, images: [SwiftUIImage], selectedImage: Binding<SwiftUIImage?>) {
+        self.description = description
+        self.images = images
+        self._selectedImage = selectedImage
+        self.placeholderIndex = 0
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: Dimension.Spacing.vstack) {
+            HStack {
+                VStack(alignment: .leading, spacing: Dimension.Spacing.textSpacing) {
+                    if let description = description {
+                        Text(description)
+                            .font(YDSFont.subtitle2)
+                    }
+                    Text("Optional<Image>")
+                        .font(YDSFont.body2)
+                }
+                Spacer()
+                Toggle("", isOn: Binding(get: {
+                    selectedImage != nil
+                }, set: { isOn in
+                    isOn ? (selectedImage = images[placeholderIndex]) : (selectedImage = nil)
+                }))
+                .labelsHidden()
+                .tint(YDSColor.buttonPoint)
+            }
+            
+            ShowPickerButton(cases: images.map({ $0.name }), selectedIndex: Binding(get: {
+                placeholderIndex
+            }, set: { index in
+                placeholderIndex = index
+                selectedImage = images[index]
+            }))
+            .disabled(selectedImage == nil)
+        }
+    }
+}
+
+struct OptionalImageOptionView_Previews: PreviewProvider {
+    static var previews: some View {
+        OptionalImageOptionView(
+            description: "image",
+            images: YDSSwiftUIImage.images,
+            selectedImage: .constant(YDSSwiftUIImage.images[0])
+        )
+    }
+}

--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalImageOptionView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalImageOptionView.swift
@@ -9,40 +9,28 @@
 import SwiftUI
 import YDS_SwiftUI
 
-
 struct OptionalImageOptionView: View {
     private enum Dimension {
         enum Spacing {
-            static let vstack: CGFloat = 8
             static let textSpacing: CGFloat = 4
         }
-        
-        enum Padding {
-            static let button: CGFloat = 16
-        }
-        
-        enum Rectangle {
-            static let cornerRadius: CGFloat = 8
-        }
     }
-    
-    @Binding private var selectedImage: SwiftUIImage?
-    
+
     private let description: String?
     private let images: [SwiftUIImage]
-    
+    @Binding private var selectedImage: SwiftUIImage?
     @State private var placeholderIndex: Int
     @State private var isPresentPicker = false
-    
+
     init(description: String?, images: [SwiftUIImage], selectedImage: Binding<SwiftUIImage?>) {
         self.description = description
         self.images = images
         self._selectedImage = selectedImage
         self.placeholderIndex = 0
     }
-    
+
     var body: some View {
-        VStack(alignment: .leading, spacing: Dimension.Spacing.vstack) {
+        VStack(alignment: .leading) {
             HStack {
                 VStack(alignment: .leading, spacing: Dimension.Spacing.textSpacing) {
                     if let description = description {
@@ -61,7 +49,7 @@ struct OptionalImageOptionView: View {
                 .labelsHidden()
                 .tint(YDSColor.buttonPoint)
             }
-            
+
             ShowPickerButton(cases: images.map({ $0.name }), selectedIndex: Binding(get: {
                 placeholderIndex
             }, set: { index in

--- a/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
@@ -81,15 +81,15 @@ struct StorybookPageView_Previews: PreviewProvider {
         enum BoxButtonType: CaseIterable {
             case filled, tinted, line
         }
-        
+
         let icons = YDSSwiftUIIcon.icons
-        
+
         @State var text: String? = "BoxButton"
         @State var isDisabled = false
         @State var numberOfLines = 1
         @State var selectedBoxButtonType = 0
         @State var icon: SwiftUIIcon?
-        
+
         return StorybookPageView(
             sample: {
                 Button(action: {}) {

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		AF75281F2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF75281E2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift */; };
 		AF7528222AA5F0A1001174E7 /* ProfileImagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7528212AA5F0A1001174E7 /* ProfileImagePageView.swift */; };
 		AF7528242AA5F637001174E7 /* OptionalImageOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7528232AA5F637001174E7 /* OptionalImageOptionView.swift */; };
+		AFA307202AAAF7CE00916C7E /* YDSProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA3071F2AAAF7CE00916C7E /* YDSProfileImageView.swift */; };
 		B9E4E8C82A90BDB90076473C /* StorybookPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */; };
 		B9E4E8CE2A90BF500076473C /* BoolOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */; };
 		B9E4E8D02A90BF7E0076473C /* EnumOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */; };
@@ -335,6 +336,7 @@
 		AF75281E2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIYDSImageArray.swift; sourceTree = "<group>"; };
 		AF7528212AA5F0A1001174E7 /* ProfileImagePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImagePageView.swift; sourceTree = "<group>"; };
 		AF7528232AA5F637001174E7 /* OptionalImageOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalImageOptionView.swift; sourceTree = "<group>"; };
+		AFA3071F2AAAF7CE00916C7E /* YDSProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YDSProfileImageView.swift; path = "YDS-Storybook/SwiftUI/Resources/YDSProfileImageView.swift"; sourceTree = SOURCE_ROOT; };
 		B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorybookPageView.swift; sourceTree = "<group>"; };
 		B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolOptionView.swift; sourceTree = "<group>"; };
 		B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumOptionView.swift; sourceTree = "<group>"; };
@@ -785,6 +787,7 @@
 		6FFDB9782A717FBF003A9519 /* Atom */ = {
 			isa = PBXGroup;
 			children = (
+				AFA3071F2AAAF7CE00916C7E /* YDSProfileImageView.swift */,
 			);
 			path = Atom;
 			sourceTree = "<group>";
@@ -1248,6 +1251,7 @@
 				6F95FE552A768C1E00B398CF /* YDSTypoStyle.swift in Sources */,
 				6F95FE542A768C1E00B398CF /* YDSItemColor.swift in Sources */,
 				6F95FE592A768C1E00B398CF /* YDSBasicColor.swift in Sources */,
+				AFA307202AAAF7CE00916C7E /* YDSProfileImageView.swift in Sources */,
 				6F95FE582A768C1E00B398CF /* YDSSemanticColor.swift in Sources */,
 				6F95FE562A768C1E00B398CF /* YDSIcon.swift in Sources */,
 				6FFDB9832A718603003A9519 /* YDSFont.swift in Sources */,

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -115,6 +115,9 @@
 		6FFDB9832A718603003A9519 /* YDSFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFDB9822A718603003A9519 /* YDSFont.swift */; };
 		956C40172A949B640098BB8F /* SwiftUIYDSTypoArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956C40162A949B640098BB8F /* SwiftUIYDSTypoArray.swift */; };
 		956C40192A949BAE0098BB8F /* TypoPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956C40182A949BAE0098BB8F /* TypoPageView.swift */; };
+		AF75281F2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF75281E2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift */; };
+		AF7528222AA5F0A1001174E7 /* ProfileImagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7528212AA5F0A1001174E7 /* ProfileImagePageView.swift */; };
+		AF7528242AA5F637001174E7 /* OptionalImageOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7528232AA5F637001174E7 /* OptionalImageOptionView.swift */; };
 		B9E4E8C82A90BDB90076473C /* StorybookPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */; };
 		B9E4E8CE2A90BF500076473C /* BoolOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */; };
 		B9E4E8D02A90BF7E0076473C /* EnumOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */; };
@@ -329,6 +332,9 @@
 		6FFDB9822A718603003A9519 /* YDSFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSFont.swift; sourceTree = "<group>"; };
 		956C40162A949B640098BB8F /* SwiftUIYDSTypoArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIYDSTypoArray.swift; sourceTree = "<group>"; };
 		956C40182A949BAE0098BB8F /* TypoPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypoPageView.swift; sourceTree = "<group>"; };
+		AF75281E2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIYDSImageArray.swift; sourceTree = "<group>"; };
+		AF7528212AA5F0A1001174E7 /* ProfileImagePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImagePageView.swift; sourceTree = "<group>"; };
+		AF7528232AA5F637001174E7 /* OptionalImageOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalImageOptionView.swift; sourceTree = "<group>"; };
 		B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorybookPageView.swift; sourceTree = "<group>"; };
 		B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolOptionView.swift; sourceTree = "<group>"; };
 		B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumOptionView.swift; sourceTree = "<group>"; };
@@ -662,6 +668,7 @@
 				6CA05E812A90846B00B07920 /* SwiftUIYDSColorArray.swift */,
 				5A10B1B52A8F5C8500139E89 /* SwiftUIYDSIconArray.swift */,
 				956C40162A949B640098BB8F /* SwiftUIYDSTypoArray.swift */,
+				AF75281E2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -672,6 +679,7 @@
 				5A10B1B42A8F5C2600139E89 /* Resources */,
 				6F2D527C2A7944D800BAF200 /* PageListView.swift */,
 				6F2D52792A79444C00BAF200 /* Foundation */,
+				AF7528202AA5F05B001174E7 /* Atom */,
 				B9E4E8C62A90BC3C0076473C /* Storybook */,
 			);
 			path = SwiftUI;
@@ -788,6 +796,14 @@
 			path = Component;
 			sourceTree = "<group>";
 		};
+		AF7528202AA5F05B001174E7 /* Atom */ = {
+			isa = PBXGroup;
+			children = (
+				AF7528212AA5F0A1001174E7 /* ProfileImagePageView.swift */,
+			);
+			path = Atom;
+			sourceTree = "<group>";
+		};
 		B9E4E8C62A90BC3C0076473C /* Storybook */ = {
 			isa = PBXGroup;
 			children = (
@@ -806,6 +822,7 @@
 				B9E4E8D12A90BF870076473C /* IntOptionView.swift */,
 				B9E4E8D32A90BFA10076473C /* OptionalStringOptionView.swift */,
 				B9E4E8D52A90BFB60076473C /* OptionalIconOptionView.swift */,
+				AF7528232AA5F637001174E7 /* OptionalImageOptionView.swift */,
 			);
 			path = OptionView;
 			sourceTree = "<group>";
@@ -1302,6 +1319,7 @@
 				6F2D527D2A7944D800BAF200 /* PageListView.swift in Sources */,
 				5337939226AF0A7300BE5860 /* BoxButtonPageViewController.swift in Sources */,
 				5359A5C126BEC99700FCCECC /* BottomBarControllerPageViewController.swift in Sources */,
+				AF75281F2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift in Sources */,
 				532DBFD726EC736C008C2354 /* UIStackView+AddArrangedSubviews.swift in Sources */,
 				538ACCAE26EB40380044A437 /* ColorsPageViewController.swift in Sources */,
 				537FFAA426C3E5C200270C22 /* TopBarPageViewController.swift in Sources */,
@@ -1359,12 +1377,14 @@
 				53C9F70626B5BCCE00EF7B86 /* ProfileImageViewPageViewController.swift in Sources */,
 				532DBFD926EC7863008C2354 /* UIViewController+Embed.swift in Sources */,
 				C3A8033728AE23D3008E2380 /* NSLineBreakMode+CustomStringConvertible.swift in Sources */,
+				AF7528242AA5F637001174E7 /* OptionalImageOptionView.swift in Sources */,
 				5A10B1B62A8F5C8500139E89 /* SwiftUIYDSIconArray.swift in Sources */,
 				533A27B326A52E56009FD90A /* PageListViewController.swift in Sources */,
 				532DBFD226EC7323008C2354 /* UITableView+Generic.swift in Sources */,
 				5359A5C526BED19900FCCECC /* DoubleTitleTopBarPageViewController.swift in Sources */,
 				B9E4E8D22A90BF870076473C /* IntOptionView.swift in Sources */,
 				538ACCB426EB40A60044A437 /* ColorsListTableViewController.swift in Sources */,
+				AF7528222AA5F0A1001174E7 /* ProfileImagePageView.swift in Sources */,
 				53441B0426AF287600CB6BC9 /* BoolControllerView.swift in Sources */,
 				53E2CF3E26D2A1ED000DE005 /* SuffixTextFieldViewPageViewController.swift in Sources */,
 				5337938C26AF096A00BE5860 /* StorybookPageViewController.swift in Sources */,


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 기존에 작업했던 Option에 `OptionalImageOptionView`를 추가하여, Icon이 아닌 이미지를 추가하는 방식에 대한 `Option`도 추가하였습니다.
- ProfileImagePageView를 구현하였습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #206 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 옵션에 Image를 적용할 수 없어서 일단 ImageArray를 추가하여 포팅할 수 있는 방식으로 사용하였습니다. -> 
- 현재 YDS SwiftUI에는 ProfileImage에 대한 컴포넌트가 없어서 해당 부분을 구현하기 위한 코드가 Storybook에 포함되어 있습니다. 이 부분 참고하시면 좋을 것 같아요. -> YDS_SwiftUI에 ProfileImageView 컴포넌트 제작 완료하였습니다.
- ProfileImage에서 바꿀 옵션을 줄 만한 부분이 Border로 보여서, Border Width와 Color를 수정할 수 있는 border 함수를 추가하도록 만들었습니다. 참고해주세요!

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

https://github.com/yourssu/YDS-iOS/assets/96258104/f84092b3-e557-4f00-a74b-b0a0e911ab0a

