### PR TITLE
[#223] Priority 설정으로 Label이 intrinsic하게 적용되도록 변경

### DIFF
--- a/YDS-Storybook/SwiftUI/Atom/LabelPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/LabelPageView.swift
@@ -29,7 +29,7 @@ import YDS_SwiftUI
                 GeometryReader { geometry in
                     YDSLabel(
                         text: text ?? "",
-                        typoStyle: String.TypoStyle.allCases[typoStyleSelectedIndex].font,
+                        typoStyle: YDSLabel.TypoStyle.allCases[typoStyleSelectedIndex],
                         textColor: selectedColor,
                         maxWidth: geometry.size.width - 32,
                         numberOfLines: int,

--- a/YDS-SwiftUI/Source/Atom/YDSLabel.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSLabel.swift
@@ -18,8 +18,75 @@ public struct YDSLabel: UIViewRepresentable {
     let alignment: NSTextAlignment?
     let lineBreakStrategy: NSParagraphStyle.LineBreakStrategy?
 
+    public enum TypoStyle: CaseIterable {
+        case display1
+        case display2
+
+        case title1
+        case title2
+        case title3
+
+        case subtitle1
+        case subtitle2
+        case subtitle3
+
+        case body1
+        case body2
+
+        case button0
+        case button1
+        case button2
+        case button3
+        case button4
+
+        case caption0
+        case caption1
+        case caption2
+
+        var uiFont: UIFont {
+            switch self {
+            case .display1:
+                return UIFont.systemFont(ofSize: 40, weight: .bold )
+            case .display2:
+                return UIFont.systemFont(ofSize: 32, weight: .bold )
+            case .title1:
+                return UIFont.systemFont(ofSize: 28, weight: .bold )
+            case .title2:
+                return UIFont.systemFont(ofSize: 24, weight: .bold )
+            case .title3:
+                return UIFont.systemFont(ofSize: 20, weight: .bold )
+            case .subtitle1:
+                return UIFont.systemFont(ofSize: 20, weight: .semibold )
+            case .subtitle2:
+                return UIFont.systemFont(ofSize: 16, weight: .semibold )
+            case .subtitle3:
+                return UIFont.systemFont(ofSize: 14, weight: .semibold )
+            case .body1:
+                return UIFont.systemFont(ofSize: 15, weight: .regular )
+            case .body2:
+                return UIFont.systemFont(ofSize: 14, weight: .regular )
+            case .button0:
+                return UIFont.systemFont(ofSize: 16, weight: .medium )
+            case .button1:
+                return UIFont.systemFont(ofSize: 16, weight: .semibold )
+            case .button2:
+                return UIFont.systemFont(ofSize: 14, weight: .semibold )
+            case .button3:
+                return UIFont.systemFont(ofSize: 14, weight: .regular )
+            case .button4:
+                return UIFont.systemFont(ofSize: 12, weight: .medium )
+            case .caption0:
+                return UIFont.systemFont(ofSize: 12, weight: .semibold )
+            case .caption1:
+                return UIFont.systemFont(ofSize: 12, weight: .regular )
+            case .caption2:
+                return UIFont.systemFont(ofSize: 11, weight: .regular )
+            }
+        }
+    }
+
     public init(text: String,
-                typoStyle: UIFont = UIFont.systemFont(ofSize: 17),
+                typoStyle: TypoStyle = .body1,
                 textColor: Color = Color.black,
                 maxWidth: CGFloat = .greatestFiniteMagnitude,
                 numberOfLines: Int = 0,
@@ -27,7 +94,7 @@ public struct YDSLabel: UIViewRepresentable {
                 alignment: NSTextAlignment = .center,
                 lineBreakStrategy: NSParagraphStyle.LineBreakStrategy = .hangulWordPriority) {
         self.text = text
-        self.typoStyle = typoStyle
+        self.typoStyle = typoStyle.uiFont
         self.textColor = textColor
         self.maxWidth = maxWidth
         self.numberOfLines = numberOfLines

--- a/YDS-SwiftUI/Source/Atom/YDSLabel.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSLabel.swift
@@ -126,6 +126,5 @@ public struct YDSLabel: UIViewRepresentable {
         uiView.textAlignment = alignment ?? .center
         uiView.lineBreakStrategy = lineBreakStrategy ?? .hangulWordPriority
         uiView.setContentHuggingPriority(.defaultHigh, for: .vertical)
-        uiView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
 }

--- a/YDS-SwiftUI/Source/Atom/YDSLabel.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSLabel.swift
@@ -58,5 +58,7 @@ public struct YDSLabel: UIViewRepresentable {
         uiView.lineBreakMode = lineBreakMode ?? .byWordWrapping
         uiView.textAlignment = alignment ?? .center
         uiView.lineBreakStrategy = lineBreakStrategy ?? .hangulWordPriority
+        uiView.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        uiView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- Label이 최대 크기로 설정되어, 다른 뷰를 잡아먹는 버그를 발견하였습니다.
![image](https://github.com/yourssu/YDS-iOS/assets/96258104/729f5e86-23f2-4747-b585-8952b2f2f1fe)

- 하지만 값으로 지정하면 여러 줄이 들어오는 경우, 뷰가 짤릴 가능성이 있습니다.
- 그래서 동적으로 지정될 수 있도록 고민하였습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #223 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 크기를 지정하지 않고 동적으로 알맞게 설정할 수 있도록 하기 위해서 방법을 고민했습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
https://stackoverflow.com/questions/56665048/how-do-i-make-my-swiftui-uiviewrepresentable-respect-intrinsiccontentsize-in-pre

https://stackoverflow.com/questions/68719533/how-do-i-change-the-height-of-this-uiviewrepresentable


## 🔥 Test
<!-- Test -->
![image](https://github.com/yourssu/YDS-iOS/assets/96258104/b5ba1c36-56cf-43d0-bb17-461616158867)

