### PR TITLE
[#218] YDS TextField 구현

### DIFF
--- a/YDS-Storybook/SwiftUI/Atom/TextField/PasswordTextFieldPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/TextField/PasswordTextFieldPageView.swift
@@ -1,0 +1,62 @@
+//
+//  PasswordTextFieldPageView.swift
+//  YDS-Storybook
+//
+//  Created by 심상현 on 2023/11/05.
+//
+
+import SwiftUI
+import YDS_SwiftUI
+
+struct PasswordTextFieldPageView: View {
+    let title: String = "ProfileImageView"
+
+    @State var fieldText: String? = "비밀번호"
+    @State var placeHolder: String? = "1234qwer!@#$"
+    @State var helperText: String? = "숫자와 영문자 조합으로 8자 이상 입력해주세요."
+    @State var text = ""
+    @State var isDisabled: Bool = false
+    @State var isNegative: Bool = false
+    @State var isPositive: Bool = false
+
+    var body: some View {
+        StorybookPageView(sample: {
+            YDSPasswordTextField(
+                fieldText: fieldText,
+                placeholder: placeHolder,
+                helperText: helperText,
+                text: $text,
+                isDisabled: isDisabled,
+                isNegative: isNegative,
+                isPositive: isPositive
+            )
+            .padding()
+        }, options: [
+            Option.optionalString(
+                description: "fieldLabelText",
+                text: $fieldText),
+            Option.optionalString(
+                description: "placeholder",
+                text: $placeHolder),
+            Option.optionalString(
+                description: "helperLabelText",
+                text: $helperText),
+            Option.bool(
+                description: "isDisabled",
+                isOn: $isDisabled),
+            Option.bool(
+                description: "isNegative",
+                isOn: $isNegative),
+            Option.bool(
+                description: "isPositive",
+                isOn: $isPositive)
+        ])
+        .navigationTitle(title)
+    }
+}
+
+struct PasswordTextFieldPageView_Previews: PreviewProvider {
+    static var previews: some View {
+        PasswordTextFieldPageView()
+    }
+}

--- a/YDS-Storybook/SwiftUI/Atom/TextField/PasswordTextFieldPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/TextField/PasswordTextFieldPageView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import YDS_SwiftUI
 
 struct PasswordTextFieldPageView: View {
-    let title: String = "ProfileImageView"
+    let title: String = "PasswordTextFieldView"
 
     @State var fieldText: String? = "비밀번호"
     @State var placeHolder: String? = "1234qwer!@#$"

--- a/YDS-Storybook/SwiftUI/Atom/TextField/SearchTextFieldPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/TextField/SearchTextFieldPageView.swift
@@ -1,0 +1,43 @@
+//
+//  SearchTextFieldPageView.swift
+//  YDS-Storybook
+//
+//  Created by 심상현 on 2023/11/05.
+//
+
+import SwiftUI
+import YDS_SwiftUI
+
+struct SearchTextFieldPageView: View {
+    let title: String = "SearchTextField"
+
+    @State var placeHolder: String? = "검색어를 입력하세요."
+    @State var text = ""
+
+    @State var isDisabled: Bool = false
+
+    var body: some View {
+        StorybookPageView(sample: {
+            YDSSearchTextField(
+                placeholder: placeHolder,
+                text: $text,
+                isDisabled: isDisabled
+            )
+            .padding()
+        }, options: [
+            Option.optionalString(
+                description: "placeholder",
+                text: $placeHolder),
+            Option.bool(
+                description: "isDisabled",
+                isOn: $isDisabled)
+        ])
+        .navigationTitle(title)
+    }
+}
+
+struct SearchTextFieldPageView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchTextFieldPageView()
+    }
+}

--- a/YDS-Storybook/SwiftUI/Atom/TextField/SimpleTextFieldPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/TextField/SimpleTextFieldPageView.swift
@@ -1,0 +1,62 @@
+//
+//  SimpleTextFieldPageView.swift
+//  YDS-Storybook
+//
+//  Created by 심상현 on 2023/10/30.
+//
+
+import SwiftUI
+import YDS_SwiftUI
+
+struct SimpleTextFieldPageView: View {
+    let title: String = "SimpleTextFieldView"
+
+    @State var fieldText: String? = "닉네임"
+    @State var placeHolder: String? = "홍길동"
+    @State var helperText: String? = "닉네임은 20글자 이하로 해주세요."
+    @State var text = ""
+    @State var isDisabled: Bool = false
+    @State var isNegative: Bool = false
+    @State var isPositive: Bool = false
+
+    var body: some View {
+        StorybookPageView(sample: {
+            YDSSimpleTextField(
+                fieldText: fieldText ?? nil,
+                placeholder: placeHolder ?? nil,
+                helperText: helperText ?? nil,
+                text: $text,
+                isDisabled: isDisabled,
+                isNegative: isNegative,
+                isPositive: isPositive
+            )
+            .padding()
+        }, options: [
+            Option.optionalString(
+                description: "fieldLabelText",
+                text: $fieldText),
+            Option.optionalString(
+                description: "placeholder",
+                text: $placeHolder),
+            Option.optionalString(
+                description: "helperLabelText",
+                text: $helperText),
+            Option.bool(
+                description: "isDisabled",
+                isOn: $isDisabled),
+            Option.bool(
+                description: "isNegative",
+                isOn: $isNegative),
+            Option.bool(
+                description: "isPositive",
+                isOn: $isPositive)
+        ])
+        .navigationTitle(title)
+    }
+}
+
+struct SimpleTextFieldPageView_Previews: PreviewProvider {
+    static var previews: some View {
+        SimpleTextFieldPageView()
+    }
+}

--- a/YDS-Storybook/SwiftUI/Atom/TextField/SuffixTextFieldPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/TextField/SuffixTextFieldPageView.swift
@@ -1,0 +1,67 @@
+//
+//  SuffixTextFieldPageView.swift
+//  YDS-Storybook
+//
+//  Created by 심상현 on 2023/11/05.
+//
+
+import SwiftUI
+import YDS_SwiftUI
+
+struct SuffixTextFieldPageView: View {
+    let title: String = "SuffixTextField"
+
+    @State var fieldText: String? = "학교 이메일"
+    @State var placeHolder: String? = "아이디"
+    @State var helperText: String? = "이메일 규칙은 어떠어떠합니다."
+    @State var text = ""
+    @State var suffixText: String? = "@soongsil.ac.kr"
+    @State var isDisabled: Bool = false
+    @State var isNegative: Bool = false
+    @State var isPositive: Bool = false
+
+    var body: some View {
+        StorybookPageView(sample: {
+            YDSSuffixTextField(
+                fieldText: fieldText ?? nil,
+                placeholder: placeHolder ?? nil,
+                helperText: helperText ?? nil,
+                text: $text,
+                suffixText: suffixText,
+                isDisabled: isDisabled,
+                isNegative: isNegative,
+                isPositive: isPositive
+            )
+            .padding()
+        }, options: [
+            Option.optionalString(
+                description: "fieldLabelText",
+                text: $fieldText),
+            Option.optionalString(
+                description: "placeholder",
+                text: $placeHolder),
+            Option.optionalString(
+                description: "suffixLabelText",
+                text: $suffixText),
+            Option.optionalString(
+                description: "helperLabelText",
+                text: $helperText),
+            Option.bool(
+                description: "isDisabled",
+                isOn: $isDisabled),
+            Option.bool(
+                description: "isNegative",
+                isOn: $isNegative),
+            Option.bool(
+                description: "isPositive",
+                isOn: $isPositive)
+        ])
+        .navigationTitle(title)
+    }
+}
+
+struct SuffixTextFieldPageView_Previews: PreviewProvider {
+    static var previews: some View {
+        SuffixTextFieldPageView()
+    }
+}

--- a/YDS-Storybook/SwiftUI/Atom/TextField/SuffixTextFieldPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/TextField/SuffixTextFieldPageView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import YDS_SwiftUI
 
 struct SuffixTextFieldPageView: View {
-    let title: String = "SuffixTextField"
+    let title: String = "SuffixTextFieldView"
 
     @State var fieldText: String? = "학교 이메일"
     @State var placeHolder: String? = "아이디"

--- a/YDS-Storybook/SwiftUI/PageListView.swift
+++ b/YDS-Storybook/SwiftUI/PageListView.swift
@@ -59,6 +59,18 @@ struct PageListView: View {
         PageView(title: "PlainButton") {
             PlainButtonPageView()
         }
+        PageView(title: "SimpleTextField") {
+            SimpleTextFieldPageView()
+        }
+        PageView(title: "SuffixTextFieldPageView") {
+            SuffixTextFieldPageView()
+        }
+        PageView(title: "SearchTextFieldPageView") {
+            SearchTextFieldPageView()
+        }
+        PageView(title: "PasswordTextFieldPageView") {
+            PasswordTextFieldPageView()
+        }
     }
 
     @ViewBuilder

--- a/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
@@ -61,7 +61,7 @@ private extension StorybookPageView {
             .frame(maxWidth: .infinity, maxHeight: YDSScreenSize.width * 3/4)
             .background(
                 Rectangle()
-                    .fill(YDSColor.monoItemBG)
+                    .fill(Color.white)
             )
     }
     

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSPasswordTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSPasswordTextField.swift
@@ -17,9 +17,9 @@ public struct YDSPasswordTextField: View, YDSTextFieldProtocol {
     let isNegative: Bool
     let isPositive: Bool
     let onSubmit: () -> Void
-
+    
     @State var isSecured: Bool = true
-
+    
     public init(
         fieldText: String? = nil,
         placeholder: String? = nil,
@@ -31,28 +31,28 @@ public struct YDSPasswordTextField: View, YDSTextFieldProtocol {
         isPositive: Bool = false,
         onSubmit: @escaping () -> Void = {}
     ) {
-            self.fieldText = fieldText
-            self.placeholder = placeholder
-            self.helperText = helperText
-            self._text = text
-            self.suffixText = suffixText
-            self.isDisabled = isDisabled
-            self.isNegative = isNegative
-            self.isPositive = isPositive
-            self.onSubmit = onSubmit
-        }
-
+        self.fieldText = fieldText
+        self.placeholder = placeholder
+        self.helperText = helperText
+        self._text = text
+        self.suffixText = suffixText
+        self.isDisabled = isDisabled
+        self.isNegative = isNegative
+        self.isPositive = isPositive
+        self.onSubmit = onSubmit
+    }
+    
     init?() {
         fatalError("Initialization failed: YDSPasswordTextField initializing failed.")
     }
-
+    
     public var body: some View {
         YDSTextFieldBase(
             fieldText: fieldText,
             placeholder: placeholder,
             helperText: helperText,
             text: $text,
-            trailing: AnyView(
+            trailing: {
                 Button(action: {
                     isSecured.toggle()
                 }) {
@@ -60,13 +60,13 @@ public struct YDSPasswordTextField: View, YDSTextFieldProtocol {
                         .accentColor(YDSColor.buttonNormal)
                         .frame(width: 24, height: 24)
                 }
-            ),
+            },
             isDisabled: isDisabled,
             isNegative: isNegative,
             isPositive: isPositive,
             isSecure: isSecured,
             onSubmit: onSubmit
-            )
+        )
     }
 }
 

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSPasswordTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSPasswordTextField.swift
@@ -1,0 +1,78 @@
+//
+//  YDSPasswordTextField.swift
+//  YDS-SwiftUI
+//
+//  Created by 심상현 on 2023/10/29.
+//
+
+import SwiftUI
+
+public struct YDSPasswordTextField: View, YDSTextFieldProtocol {
+    let fieldText: String?
+    let placeholder: String?
+    let helperText: String?
+    @Binding var text: String
+    let suffixText: String?
+    let isDisabled: Bool
+    let isNegative: Bool
+    let isPositive: Bool
+
+    @State var isSecured: Bool = true
+
+    public init(
+        fieldText: String? = nil,
+        placeholder: String? = nil,
+        helperText: String? = nil,
+        text: Binding<String>,
+        suffixText: String? = nil,
+        isDisabled: Bool = false,
+        isNegative: Bool = false,
+        isPositive: Bool = false
+    ) {
+            self.fieldText = fieldText
+            self.placeholder = placeholder
+            self.helperText = helperText
+            self._text = text
+            self.suffixText = suffixText
+            self.isDisabled = isDisabled
+            self.isNegative = isNegative
+            self.isPositive = isPositive
+        }
+
+    init?() {
+        fatalError("Initialization failed: YDSProfileImageView requires an Image and a size to be initialized.")
+    }
+
+    public var body: some View {
+        YDSTextFieldBase(
+            fieldText: fieldText,
+            placeholder: placeholder,
+            helperText: helperText,
+            text: $text,
+            trailing: AnyView(
+                Button(action: {
+                    isSecured.toggle()
+                }) {
+                    Image(systemName: self.isSecured ? "eye.slash" : "eye")
+                        .accentColor(YDSColor.buttonNormal)
+                        .frame(width: 24, height: 24)
+                }
+            ),
+            isDisabled: isDisabled,
+            isNegative: isNegative,
+            isPositive: isPositive,
+            isSecure: isSecured
+            )
+    }
+}
+
+struct YDSPasswordTextField_Previews: PreviewProvider {
+    static var previews: some View {
+        YDSPasswordTextField(
+            fieldText: "fieldText",
+            placeholder: "placeHolder",
+            helperText: "helperText",
+            text: .constant("")
+        )
+    }
+}

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSPasswordTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSPasswordTextField.swift
@@ -43,7 +43,7 @@ public struct YDSPasswordTextField: View, YDSTextFieldProtocol {
         }
 
     init?() {
-        fatalError("Initialization failed: YDSProfileImageView requires an Image and a size to be initialized.")
+        fatalError("Initialization failed: YDSPasswordTextField initializing failed.")
     }
 
     public var body: some View {

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSPasswordTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSPasswordTextField.swift
@@ -16,6 +16,7 @@ public struct YDSPasswordTextField: View, YDSTextFieldProtocol {
     let isDisabled: Bool
     let isNegative: Bool
     let isPositive: Bool
+    let onSubmit: () -> Void
 
     @State var isSecured: Bool = true
 
@@ -27,7 +28,8 @@ public struct YDSPasswordTextField: View, YDSTextFieldProtocol {
         suffixText: String? = nil,
         isDisabled: Bool = false,
         isNegative: Bool = false,
-        isPositive: Bool = false
+        isPositive: Bool = false,
+        onSubmit: @escaping () -> Void = {}
     ) {
             self.fieldText = fieldText
             self.placeholder = placeholder
@@ -37,6 +39,7 @@ public struct YDSPasswordTextField: View, YDSTextFieldProtocol {
             self.isDisabled = isDisabled
             self.isNegative = isNegative
             self.isPositive = isPositive
+            self.onSubmit = onSubmit
         }
 
     init?() {
@@ -61,7 +64,8 @@ public struct YDSPasswordTextField: View, YDSTextFieldProtocol {
             isDisabled: isDisabled,
             isNegative: isNegative,
             isPositive: isPositive,
-            isSecure: isSecured
+            isSecure: isSecured,
+            onSubmit: onSubmit
             )
     }
 }

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSearchTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSearchTextField.swift
@@ -30,7 +30,7 @@ public struct YDSSearchTextField: View, YDSTextFieldProtocol {
     }
 
     init?() {
-        fatalError("Initialization failed: YDSProfileImageView requires an Image and a size to be initialized.")
+        fatalError("Initialization failed: YDSSearchTextField initializing failed.")
     }
 
     public var body: some View {

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSearchTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSearchTextField.swift
@@ -1,0 +1,68 @@
+//
+//  YDSSearchTextField.swift
+//  YDS-SwiftUI
+//
+//  Created by 심상현 on 2023/10/29.
+//
+
+import SwiftUI
+
+public struct YDSSearchTextField: View, YDSTextFieldProtocol {
+    let isNegative: Bool = false
+    let isPositive: Bool = false
+    let fieldText: String? = nil
+    let helperText: String? = nil
+
+    @Binding var text: String
+    let placeholder: String?
+    let isDisabled: Bool
+
+    public init(
+        placeholder: String? = nil,
+        text: Binding<String>,
+        isDisabled: Bool = false
+    ) {
+        self.placeholder = placeholder
+        self._text = text
+        self.isDisabled = isDisabled
+    }
+
+    init?() {
+        fatalError("Initialization failed: YDSProfileImageView requires an Image and a size to be initialized.")
+    }
+
+    public var body: some View {
+        YDSTextFieldBase(
+            placeholder: placeholder,
+            leading: AnyView(
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(YDSColor.textTertiary)
+            ),
+            text: $text,
+            trailing:
+                AnyView(
+                    Group {
+                        if !text.isEmpty {
+                            Button(action: {
+                                text = ""
+                            }, label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.secondary)
+                            })
+                        }
+                    }
+                ),
+            isDisabled: isDisabled
+        )
+    }
+}
+
+struct YDSSearchTextField_Previews: PreviewProvider {
+    static var previews: some View {
+        YDSSearchTextField(
+            placeholder: "placeHolder",
+            text: .constant(""),
+            isDisabled: false
+        )
+    }
+}

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSearchTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSearchTextField.swift
@@ -12,19 +12,21 @@ public struct YDSSearchTextField: View, YDSTextFieldProtocol {
     let isPositive: Bool = false
     let fieldText: String? = nil
     let helperText: String? = nil
-
     @Binding var text: String
     let placeholder: String?
     let isDisabled: Bool
+    let onSubmit: () -> Void
 
     public init(
         placeholder: String? = nil,
         text: Binding<String>,
-        isDisabled: Bool = false
+        isDisabled: Bool = false,
+        onSubmit: @escaping () -> Void = {}
     ) {
         self.placeholder = placeholder
         self._text = text
         self.isDisabled = isDisabled
+        self.onSubmit = onSubmit
     }
 
     init?() {
@@ -52,7 +54,8 @@ public struct YDSSearchTextField: View, YDSTextFieldProtocol {
                         }
                     }
                 ),
-            isDisabled: isDisabled
+            isDisabled: isDisabled,
+            onSubmit: onSubmit
         )
     }
 }

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSearchTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSearchTextField.swift
@@ -16,7 +16,7 @@ public struct YDSSearchTextField: View, YDSTextFieldProtocol {
     let placeholder: String?
     let isDisabled: Bool
     let onSubmit: () -> Void
-
+    
     public init(
         placeholder: String? = nil,
         text: Binding<String>,
@@ -28,20 +28,20 @@ public struct YDSSearchTextField: View, YDSTextFieldProtocol {
         self.isDisabled = isDisabled
         self.onSubmit = onSubmit
     }
-
+    
     init?() {
         fatalError("Initialization failed: YDSSearchTextField initializing failed.")
     }
-
+    
     public var body: some View {
         YDSTextFieldBase(
             placeholder: placeholder,
-            leading: AnyView(
+            leading: {
                 Image(systemName: "magnifyingglass")
                     .foregroundColor(YDSColor.textTertiary)
-            ),
+            },
             text: $text,
-            trailing:
+            trailing: {
                 AnyView(
                     Group {
                         if !text.isEmpty {
@@ -53,7 +53,8 @@ public struct YDSSearchTextField: View, YDSTextFieldProtocol {
                             })
                         }
                     }
-                ),
+                )
+            },
             isDisabled: isDisabled,
             onSubmit: onSubmit
         )

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSimpleTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSimpleTextField.swift
@@ -8,13 +8,14 @@
 import SwiftUI
 
 public struct YDSSimpleTextField: View, YDSTextFieldProtocol {
-    var fieldText: String?
-    var placeholder: String?
-    var helperText: String?
+    let fieldText: String?
+    let placeholder: String?
+    let helperText: String?
     @Binding var text: String
-    var isDisabled: Bool
-    var isNegative: Bool
-    var isPositive: Bool
+    let isDisabled: Bool
+    let isNegative: Bool
+    let isPositive: Bool
+    let onSubmit: () -> Void
 
     public init(
         fieldText: String? = nil,
@@ -23,7 +24,8 @@ public struct YDSSimpleTextField: View, YDSTextFieldProtocol {
         text: Binding<String>,
         isDisabled: Bool = false,
         isNegative: Bool = false,
-        isPositive: Bool = false
+        isPositive: Bool = false,
+        onSubmit: @escaping () -> Void = {}
     ) {
         self.fieldText = fieldText
         self.placeholder = placeholder
@@ -32,6 +34,7 @@ public struct YDSSimpleTextField: View, YDSTextFieldProtocol {
         self.isDisabled = isDisabled
         self.isNegative = isNegative
         self.isPositive = isPositive
+        self.onSubmit = onSubmit
     }
 
     init?() {
@@ -61,7 +64,8 @@ public struct YDSSimpleTextField: View, YDSTextFieldProtocol {
             ),
             isDisabled: isDisabled,
             isNegative: isNegative,
-            isPositive: isPositive
+            isPositive: isPositive,
+            onSubmit: onSubmit
          )
     }
 }

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSimpleTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSimpleTextField.swift
@@ -38,7 +38,7 @@ public struct YDSSimpleTextField: View, YDSTextFieldProtocol {
     }
 
     init?() {
-        fatalError("Initialization failed: YDSProfileImageView requires an Image and a size to be initialized.")
+        fatalError("Initialization failed: YDSSimpleTextField initializing failed.")
     }
 
     public var body: some View {

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSimpleTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSimpleTextField.swift
@@ -1,0 +1,78 @@
+//
+//  YDSSimpleTextField.swift
+//  YDS-SwiftUI
+//
+//  Created by 심상현 on 2023/10/29.
+//
+
+import SwiftUI
+
+public struct YDSSimpleTextField: View, YDSTextFieldProtocol {
+    var fieldText: String?
+    var placeholder: String?
+    var helperText: String?
+    @Binding var text: String
+    var isDisabled: Bool
+    var isNegative: Bool
+    var isPositive: Bool
+
+    public init(
+        fieldText: String? = nil,
+        placeholder: String? = nil,
+        helperText: String? = nil,
+        text: Binding<String>,
+        isDisabled: Bool = false,
+        isNegative: Bool = false,
+        isPositive: Bool = false
+    ) {
+        self.fieldText = fieldText
+        self.placeholder = placeholder
+        self.helperText = helperText
+        self._text = text
+        self.isDisabled = isDisabled
+        self.isNegative = isNegative
+        self.isPositive = isPositive
+    }
+
+    init?() {
+        fatalError("Initialization failed: YDSProfileImageView requires an Image and a size to be initialized.")
+    }
+
+    public var body: some View {
+        YDSTextFieldBase(
+            fieldText: fieldText,
+            placeholder: placeholder,
+            helperText: helperText,
+            text: $text,
+            trailing:
+                AnyView(
+                    Group {
+                    if !text.isEmpty {
+                        Button(action: {
+                            text = ""
+                        }, label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.secondary)
+                        })
+                    } else {
+                        EmptyView()
+                    }
+                }
+            ),
+            isDisabled: isDisabled,
+            isNegative: isNegative,
+            isPositive: isPositive
+         )
+    }
+}
+
+struct YDSSimpleTextField_Previews: PreviewProvider {
+    static var previews: some View {
+        YDSSimpleTextField(
+            fieldText: "hello world",
+            placeholder: "hello world",
+            helperText: "helper",
+            text: .constant("")
+        )
+    }
+}

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSimpleTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSimpleTextField.swift
@@ -47,7 +47,7 @@ public struct YDSSimpleTextField: View, YDSTextFieldProtocol {
             placeholder: placeholder,
             helperText: helperText,
             text: $text,
-            trailing:
+            trailing:{
                 AnyView(
                     Group {
                     if !text.isEmpty {
@@ -61,7 +61,7 @@ public struct YDSSimpleTextField: View, YDSTextFieldProtocol {
                         EmptyView()
                     }
                 }
-            ),
+            )},
             isDisabled: isDisabled,
             isNegative: isNegative,
             isPositive: isPositive,

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSuffixTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSuffixTextField.swift
@@ -16,6 +16,7 @@ public struct YDSSuffixTextField: View, YDSTextFieldProtocol {
     let isDisabled: Bool
     let isNegative: Bool
     let isPositive: Bool
+    let onSubmit: () -> Void
 
     public init(
         fieldText: String? = nil,
@@ -25,7 +26,9 @@ public struct YDSSuffixTextField: View, YDSTextFieldProtocol {
         suffixText: String? = nil,
         isDisabled: Bool = false,
         isNegative: Bool = false,
-        isPositive: Bool = false) {
+        isPositive: Bool = false,
+        onSubmit: @escaping () -> Void = {}
+    ) {
             self.fieldText = fieldText
             self.placeholder = placeholder
             self.helperText = helperText
@@ -34,6 +37,7 @@ public struct YDSSuffixTextField: View, YDSTextFieldProtocol {
             self.isDisabled = isDisabled
             self.isNegative = isNegative
             self.isPositive = isPositive
+            self.onSubmit = onSubmit
         }
 
     init?() {
@@ -61,7 +65,8 @@ public struct YDSSuffixTextField: View, YDSTextFieldProtocol {
             ),
             isDisabled: isDisabled,
             isNegative: isNegative,
-            isPositive: isPositive
+            isPositive: isPositive,
+            onSubmit: onSubmit
             )
     }
 }

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSuffixTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSuffixTextField.swift
@@ -45,24 +45,24 @@ public struct YDSSuffixTextField: View, YDSTextFieldProtocol {
     }
 
     public var body: some View {
-        YDSTextFieldBase(
+        YDSTextFieldBase<EmptyView, AnyView>(
             fieldText: fieldText,
             placeholder: placeholder,
             helperText: helperText,
             text: $text,
-            trailing:
+            trailing: {
                 AnyView(
-                    Group {
-                        if let suffixText {
-                            YDSLabel(
-                                text: suffixText,
-                                textColor: YDSColor.textTertiary
-                            )
-                        } else {
-                            EmptyView()
-                        }
-                }
-            ),
+                Group {
+                    if let suffixText {
+                        YDSLabel(
+                            text: suffixText,
+                            textColor: YDSColor.textTertiary
+                        )
+                    } else {
+                        EmptyView()
+                    }
+                })
+            },
             isDisabled: isDisabled,
             isNegative: isNegative,
             isPositive: isPositive,

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSuffixTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSuffixTextField.swift
@@ -41,7 +41,7 @@ public struct YDSSuffixTextField: View, YDSTextFieldProtocol {
         }
 
     init?() {
-        fatalError("Initialization failed: YDSProfileImageView requires an Image and a size to be initialized.")
+        fatalError("Initialization failed: YDSSuffixTextField initializing failed.")
     }
 
     public var body: some View {

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSuffixTextField.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSSuffixTextField.swift
@@ -1,0 +1,80 @@
+//
+//  YDSSuffixTextField.swift
+//  YDS-SwiftUI
+//
+//  Created by 심상현 on 2023/10/29.
+//
+
+import SwiftUI
+
+public struct YDSSuffixTextField: View, YDSTextFieldProtocol {
+    let fieldText: String?
+    let placeholder: String?
+    let helperText: String?
+    @Binding var text: String
+    let suffixText: String?
+    let isDisabled: Bool
+    let isNegative: Bool
+    let isPositive: Bool
+
+    public init(
+        fieldText: String? = nil,
+        placeholder: String? = nil,
+        helperText: String? = nil,
+        text: Binding<String>,
+        suffixText: String? = nil,
+        isDisabled: Bool = false,
+        isNegative: Bool = false,
+        isPositive: Bool = false) {
+            self.fieldText = fieldText
+            self.placeholder = placeholder
+            self.helperText = helperText
+            self._text = text
+            self.suffixText = suffixText
+            self.isDisabled = isDisabled
+            self.isNegative = isNegative
+            self.isPositive = isPositive
+        }
+
+    init?() {
+        fatalError("Initialization failed: YDSProfileImageView requires an Image and a size to be initialized.")
+    }
+
+    public var body: some View {
+        YDSTextFieldBase(
+            fieldText: fieldText,
+            placeholder: placeholder,
+            helperText: helperText,
+            text: $text,
+            trailing:
+                AnyView(
+                    Group {
+                        if let suffixText {
+                            YDSLabel(
+                                text: suffixText,
+                                textColor: YDSColor.textTertiary
+                            )
+                        } else {
+                            EmptyView()
+                        }
+                }
+            ),
+            isDisabled: isDisabled,
+            isNegative: isNegative,
+            isPositive: isPositive
+            )
+    }
+}
+
+struct YDSSuffixTextField_Previews: PreviewProvider {
+    static var previews: some View {
+        YDSSuffixTextField(
+            fieldText: "hello world",
+            placeholder: "hello world",
+            helperText: "helper",
+            text: .constant(""),
+            suffixText: "Hello world",
+            isNegative: true
+        )
+    }
+}

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
@@ -54,7 +54,7 @@ struct YDSTextFieldBase: View {
             self.helperTextColor = YDSColor.textTertiary
 
             self.isSecure = isSecure
-        self.textColor = YDSColor.textSecondary
+            self.textColor = YDSColor.textSecondary
 
             /// isDisabled > isNegative > isPositive
             if isDisabled {

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
@@ -23,8 +23,8 @@ struct YDSTextFieldBase: View {
     private var borderColor: Color
     private var helperTextColor: Color
     private var textColor: Color
-
     private let isSecure: Bool
+    private let onSubmit: () -> Void
 
     init(
         fieldText: String? = nil,
@@ -37,7 +37,8 @@ struct YDSTextFieldBase: View {
         isNegative: Bool = false,
         isPositive: Bool = false,
         borderColor: Color = .clear,
-        isSecure: Bool = false
+        isSecure: Bool = false,
+        onSubmit: @escaping () -> Void = {}
     ) {
             self.fieldText = fieldText
             self.placeholder = placeholder
@@ -55,6 +56,8 @@ struct YDSTextFieldBase: View {
 
             self.isSecure = isSecure
             self.textColor = YDSColor.textSecondary
+
+            self.onSubmit = onSubmit
 
             /// isDisabled > isNegative > isPositive
             if isDisabled {
@@ -107,6 +110,9 @@ struct YDSTextFieldBase: View {
                         .accentColor(YDSColor.textPointed)
                         .foregroundColor(textColor)
                         .disabled(isDisabled)
+                        .onSubmit {
+                            onSubmit()
+                        }
                 }
 
                 trailing

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
@@ -1,0 +1,148 @@
+//
+//  YDSTextFieldBase.swift
+//  YDS-SwiftUI
+//
+//  Created by 심상현 on 2023/11/01.
+//
+
+import SwiftUI
+
+struct YDSTextFieldBase: View {
+    private let fieldText: String?
+    private let placeholder: String?
+    private let helperText: String?
+    private let text: Binding<String>
+    private let isDisabled: Bool
+    private let isNegative: Bool
+    private let isPositive: Bool
+
+    private let leading: AnyView?
+    private let trailing: AnyView?
+
+    private var fieldTextColor: Color
+    private var borderColor: Color
+    private var helperTextColor: Color
+    private var textColor: Color
+
+    private let isSecure: Bool
+
+    init(
+        fieldText: String? = nil,
+        placeholder: String? = nil,
+        helperText: String? = nil,
+        leading: AnyView? = AnyView(EmptyView()),
+        text: Binding<String>,
+        trailing: AnyView? = AnyView(EmptyView()),
+        isDisabled: Bool = false,
+        isNegative: Bool = false,
+        isPositive: Bool = false,
+        borderColor: Color = .clear,
+        isSecure: Bool = false
+    ) {
+            self.fieldText = fieldText
+            self.placeholder = placeholder
+            self.helperText = helperText
+            self.leading = leading
+            self.text = text
+            self.trailing = trailing
+            self.isDisabled = isDisabled
+            self.isNegative = isNegative
+            self.isPositive = isPositive
+
+            self.fieldTextColor = YDSColor.textSecondary
+            self.borderColor = borderColor
+            self.helperTextColor = YDSColor.textTertiary
+
+            self.isSecure = isSecure
+        self.textColor = YDSColor.textSecondary
+
+            /// isDisabled > isNegative > isPositive
+            if isDisabled {
+                self.fieldTextColor = YDSColor.textDisabled
+                self.borderColor = .clear
+                self.helperTextColor = YDSColor.textDisabled
+                self.textColor = YDSColor.textDisabled
+                return
+            }
+
+            if isNegative {
+                self.fieldTextColor = YDSColor.textSecondary
+                self.borderColor = YDSColor.textWarned
+                self.helperTextColor = YDSColor.textWarned
+                return
+            }
+
+            if isPositive {
+                self.fieldTextColor = YDSColor.textSecondary
+                self.borderColor = YDSColor.textPointed
+                self.helperTextColor = YDSColor.textTertiary
+                return
+            }
+        }
+
+    init?() {
+        fatalError("Initialization failed: YDSTextField requires an Image and a size to be initialized.")
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading) {
+            if let fieldText {
+                YDSLabel(
+                    text: fieldText,
+                    textColor: fieldTextColor,
+                    alignment: NSTextAlignment.left
+                )
+            }
+
+            HStack {
+                leading
+
+                if isSecure {
+                    SecureField(placeholder ?? "", text: text)
+                        .accentColor(YDSColor.textPointed)
+                        .foregroundColor(textColor)
+                        .disabled(isDisabled)
+                } else {
+                    TextField(placeholder ?? "", text: text)
+                        .accentColor(YDSColor.textPointed)
+                        .foregroundColor(textColor)
+                        .disabled(isDisabled)
+                }
+
+                trailing
+            }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(YDSColor.inputFieldElevated)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(borderColor)
+            )
+
+            if let helperText {
+                YDSLabel(
+                    text: helperText,
+                    textColor: helperTextColor,
+                    alignment: NSTextAlignment.left
+                )
+                .padding(.horizontal, 8)
+            }
+        }
+    }
+}
+
+struct YDSTextFieldBase_Previews: PreviewProvider {
+    static var previews: some View {
+        YDSTextFieldBase(
+            fieldText: "hello world",
+            placeholder: "hello world",
+            helperText: "helper",
+            leading: AnyView(YDSLabel(text: "le")),
+            text: .constant(""),
+            trailing: AnyView(YDSLabel(text: "tr"))
+        ).padding()
+    }
+}

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
@@ -7,17 +7,17 @@
 
 import SwiftUI
 
-struct YDSTextFieldBase: View {
+struct YDSTextFieldBase<Leading: View, Trailing: View>: View {
     private let fieldText: String?
     private let placeholder: String?
     private let helperText: String?
-    private let text: Binding<String>
+    @Binding private var text: String
     private let isDisabled: Bool
     private let isNegative: Bool
     private let isPositive: Bool
 
-    private let leading: AnyView?
-    private let trailing: AnyView?
+    @ViewBuilder private var leading: () -> Leading?
+    @ViewBuilder private var trailing: () -> Trailing?
 
     private var fieldTextColor: Color
     private var borderColor: Color
@@ -30,9 +30,9 @@ struct YDSTextFieldBase: View {
         fieldText: String? = nil,
         placeholder: String? = nil,
         helperText: String? = nil,
-        leading: AnyView? = AnyView(EmptyView()),
+        @ViewBuilder leading: @escaping () -> Leading? = { EmptyView() },
         text: Binding<String>,
-        trailing: AnyView? = AnyView(EmptyView()),
+        @ViewBuilder trailing: @escaping () -> Trailing? = { EmptyView() },
         isDisabled: Bool = false,
         isNegative: Bool = false,
         isPositive: Bool = false,
@@ -44,7 +44,7 @@ struct YDSTextFieldBase: View {
             self.placeholder = placeholder
             self.helperText = helperText
             self.leading = leading
-            self.text = text
+            self._text = text
             self.trailing = trailing
             self.isDisabled = isDisabled
             self.isNegative = isNegative
@@ -98,15 +98,15 @@ struct YDSTextFieldBase: View {
             }
 
             HStack {
-                leading
-
+                leading()
+                
                 if isSecure {
-                    SecureField(placeholder ?? "", text: text)
+                    SecureField(placeholder ?? "", text: $text)
                         .accentColor(YDSColor.textPointed)
                         .foregroundColor(textColor)
                         .disabled(isDisabled)
                 } else {
-                    TextField(placeholder ?? "", text: text)
+                    TextField(placeholder ?? "", text: $text)
                         .accentColor(YDSColor.textPointed)
                         .foregroundColor(textColor)
                         .disabled(isDisabled)
@@ -115,7 +115,7 @@ struct YDSTextFieldBase: View {
                         }
                 }
 
-                trailing
+                trailing()
             }
             .padding(.vertical, 12)
             .padding(.horizontal, 16)
@@ -146,9 +146,9 @@ struct YDSTextFieldBase_Previews: PreviewProvider {
             fieldText: "hello world",
             placeholder: "hello world",
             helperText: "helper",
-            leading: AnyView(YDSLabel(text: "le")),
+            leading: { YDSLabel(text: "le") },
             text: .constant(""),
-            trailing: AnyView(YDSLabel(text: "tr"))
+            trailing: { YDSLabel(text: "tr") }
         ).padding()
     }
 }

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
@@ -84,7 +84,7 @@ struct YDSTextFieldBase: View {
         }
 
     init?() {
-        fatalError("Initialization failed: YDSTextField requires an Image and a size to be initialized.")
+        fatalError("Initialization failed: YDSTextFieldBase initializing failed.")
     }
 
     public var body: some View {

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldProtocol.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  YDSTextFieldBase.swift
+//  YDS-SwiftUI
+//
+//  Created by 심상현 on 2023/10/29.
+//
+
+import SwiftUI
+
+protocol YDSTextFieldProtocol {
+    var placeholder: String? { get }
+    var helperText: String? { get }
+    var fieldText: String? { get }
+    var text: String { get }
+    /// 우선순위는 isDisabled > isNegative > isPositive
+    var isDisabled: Bool { get }
+    var isNegative: Bool { get }
+    var isPositive: Bool { get }
+}

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -123,10 +123,20 @@
 		956C40192A949BAE0098BB8F /* TypoPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956C40182A949BAE0098BB8F /* TypoPageView.swift */; };
 		95E535C72AB482E200FA2492 /* LabelPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E535C62AB482E200FA2492 /* LabelPageView.swift */; };
 		AF1E6F002AB88DEB0071C963 /* YDSToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1E6EFF2AB88DEB0071C963 /* YDSToast.swift */; };
+		AF23ED812AEE9BF600F3D5E2 /* YDSSimpleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF23ED802AEE9BF600F3D5E2 /* YDSSimpleTextField.swift */; };
+		AF23ED832AEE9C0F00F3D5E2 /* YDSSuffixTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF23ED822AEE9C0F00F3D5E2 /* YDSSuffixTextField.swift */; };
+		AF23ED852AEE9C1F00F3D5E2 /* YDSPasswordTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF23ED842AEE9C1E00F3D5E2 /* YDSPasswordTextField.swift */; };
+		AF23ED872AEE9C2800F3D5E2 /* YDSSearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF23ED862AEE9C2800F3D5E2 /* YDSSearchTextField.swift */; };
+		AF23ED892AEE9C7700F3D5E2 /* YDSTextFieldProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF23ED882AEE9C7700F3D5E2 /* YDSTextFieldProtocol.swift */; };
 		AF75281F2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF75281E2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift */; };
 		AF7528222AA5F0A1001174E7 /* ProfileImagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7528212AA5F0A1001174E7 /* ProfileImagePageView.swift */; };
 		AF7528242AA5F637001174E7 /* OptionalImageOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7528232AA5F637001174E7 /* OptionalImageOptionView.swift */; };
+		AF84C5602AF761AB00371DB0 /* SuffixTextFieldPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF84C55F2AF761AB00371DB0 /* SuffixTextFieldPageView.swift */; };
+		AF84C5622AF762A400371DB0 /* PasswordTextFieldPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF84C5612AF762A400371DB0 /* PasswordTextFieldPageView.swift */; };
+		AF84C5642AF7638F00371DB0 /* SearchTextFieldPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF84C5632AF7638F00371DB0 /* SearchTextFieldPageView.swift */; };
 		AFA307202AAAF7CE00916C7E /* YDSProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA3071F2AAAF7CE00916C7E /* YDSProfileImageView.swift */; };
+		AFEC225F2AEFF56800B062F4 /* SimpleTextFieldPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEC225E2AEFF56800B062F4 /* SimpleTextFieldPageView.swift */; };
+		AFFD69422AF1D52400CC8A1B /* YDSTextFieldBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFFD69412AF1D52400CC8A1B /* YDSTextFieldBase.swift */; };
 		B9E4E8C82A90BDB90076473C /* StorybookPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */; };
 		B9E4E8CE2A90BF500076473C /* BoolOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */; };
 		B9E4E8D02A90BF7E0076473C /* EnumOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */; };
@@ -349,10 +359,20 @@
 		956C40182A949BAE0098BB8F /* TypoPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypoPageView.swift; sourceTree = "<group>"; };
 		95E535C62AB482E200FA2492 /* LabelPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelPageView.swift; sourceTree = "<group>"; };
 		AF1E6EFF2AB88DEB0071C963 /* YDSToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSToast.swift; sourceTree = "<group>"; };
+		AF23ED802AEE9BF600F3D5E2 /* YDSSimpleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSSimpleTextField.swift; sourceTree = "<group>"; };
+		AF23ED822AEE9C0F00F3D5E2 /* YDSSuffixTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSSuffixTextField.swift; sourceTree = "<group>"; };
+		AF23ED842AEE9C1E00F3D5E2 /* YDSPasswordTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSPasswordTextField.swift; sourceTree = "<group>"; };
+		AF23ED862AEE9C2800F3D5E2 /* YDSSearchTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSSearchTextField.swift; sourceTree = "<group>"; };
+		AF23ED882AEE9C7700F3D5E2 /* YDSTextFieldProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTextFieldProtocol.swift; sourceTree = "<group>"; };
 		AF75281E2AA5BF08001174E7 /* SwiftUIYDSImageArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIYDSImageArray.swift; sourceTree = "<group>"; };
 		AF7528212AA5F0A1001174E7 /* ProfileImagePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImagePageView.swift; sourceTree = "<group>"; };
 		AF7528232AA5F637001174E7 /* OptionalImageOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalImageOptionView.swift; sourceTree = "<group>"; };
+		AF84C55F2AF761AB00371DB0 /* SuffixTextFieldPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuffixTextFieldPageView.swift; sourceTree = "<group>"; };
+		AF84C5612AF762A400371DB0 /* PasswordTextFieldPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordTextFieldPageView.swift; sourceTree = "<group>"; };
+		AF84C5632AF7638F00371DB0 /* SearchTextFieldPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextFieldPageView.swift; sourceTree = "<group>"; };
 		AFA3071F2AAAF7CE00916C7E /* YDSProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YDSProfileImageView.swift; path = "YDS-SwiftUI/Source/Atom/YDSProfileImageView.swift"; sourceTree = SOURCE_ROOT; };
+		AFEC225E2AEFF56800B062F4 /* SimpleTextFieldPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTextFieldPageView.swift; sourceTree = "<group>"; };
+		AFFD69412AF1D52400CC8A1B /* YDSTextFieldBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTextFieldBase.swift; sourceTree = "<group>"; };
 		B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorybookPageView.swift; sourceTree = "<group>"; };
 		B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolOptionView.swift; sourceTree = "<group>"; };
 		B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumOptionView.swift; sourceTree = "<group>"; };
@@ -816,6 +836,7 @@
 				951261312AB969560012B5F9 /* YDSLabel.swift */,
 				0299354D2AEF83F000F46712 /* YDSBoxButton.swift */,
 				026BCF202B0261BA00AE91E9 /* YDSPlainButton.swift */,
+				AF23ED7F2AEE9BBB00F3D5E2 /* YDSTextField */,
 			);
 			path = Atom;
 			sourceTree = "<group>";
@@ -828,6 +849,19 @@
 			path = Component;
 			sourceTree = "<group>";
 		};
+		AF23ED7F2AEE9BBB00F3D5E2 /* YDSTextField */ = {
+			isa = PBXGroup;
+			children = (
+				AF23ED882AEE9C7700F3D5E2 /* YDSTextFieldProtocol.swift */,
+				AFFD69412AF1D52400CC8A1B /* YDSTextFieldBase.swift */,
+				AF23ED802AEE9BF600F3D5E2 /* YDSSimpleTextField.swift */,
+				AF23ED822AEE9C0F00F3D5E2 /* YDSSuffixTextField.swift */,
+				AF23ED862AEE9C2800F3D5E2 /* YDSSearchTextField.swift */,
+				AF23ED842AEE9C1E00F3D5E2 /* YDSPasswordTextField.swift */,
+			);
+			path = YDSTextField;
+			sourceTree = "<group>";
+		};
 		AF7528202AA5F05B001174E7 /* Atom */ = {
 			isa = PBXGroup;
 			children = (
@@ -835,8 +869,20 @@
 				95E535C62AB482E200FA2492 /* LabelPageView.swift */,
 				0299354F2AEF84D400F46712 /* BoxButtonPageView.swift */,
 				026BCF1E2B02619C00AE91E9 /* PlainButtonPageView.swift */,
+				AFEC225D2AEFF54500B062F4 /* TextField */,
 			);
 			path = Atom;
+			sourceTree = "<group>";
+		};
+		AFEC225D2AEFF54500B062F4 /* TextField */ = {
+			isa = PBXGroup;
+			children = (
+				AFEC225E2AEFF56800B062F4 /* SimpleTextFieldPageView.swift */,
+				AF84C55F2AF761AB00371DB0 /* SuffixTextFieldPageView.swift */,
+				AF84C5632AF7638F00371DB0 /* SearchTextFieldPageView.swift */,
+				AF84C5612AF762A400371DB0 /* PasswordTextFieldPageView.swift */,
+			);
+			path = TextField;
 			sourceTree = "<group>";
 		};
 		B9E4E8C62A90BC3C0076473C /* Storybook */ = {
@@ -1280,18 +1326,24 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF23ED832AEE9C0F00F3D5E2 /* YDSSuffixTextField.swift in Sources */,
+				AF23ED852AEE9C1F00F3D5E2 /* YDSPasswordTextField.swift in Sources */,
 				6F95FE552A768C1E00B398CF /* YDSTypoStyle.swift in Sources */,
 				6F95FE542A768C1E00B398CF /* YDSItemColor.swift in Sources */,
 				6F95FE592A768C1E00B398CF /* YDSBasicColor.swift in Sources */,
+				AFFD69422AF1D52400CC8A1B /* YDSTextFieldBase.swift in Sources */,
 				AFA307202AAAF7CE00916C7E /* YDSProfileImageView.swift in Sources */,
 				6F95FE582A768C1E00B398CF /* YDSSemanticColor.swift in Sources */,
 				6F95FE562A768C1E00B398CF /* YDSIcon.swift in Sources */,
 				0299354E2AEF83F000F46712 /* YDSBoxButton.swift in Sources */,
 				6FFDB9832A718603003A9519 /* YDSFont.swift in Sources */,
+				AF23ED872AEE9C2800F3D5E2 /* YDSSearchTextField.swift in Sources */,
 				6F956F1E2A8D5F560023D0E3 /* Exported.swift in Sources */,
+				AF23ED812AEE9BF600F3D5E2 /* YDSSimpleTextField.swift in Sources */,
 				AF1E6F002AB88DEB0071C963 /* YDSToast.swift in Sources */,
 				951261322AB969560012B5F9 /* YDSLabel.swift in Sources */,
 				026BCF212B0261BA00AE91E9 /* YDSPlainButton.swift in Sources */,
+				AF23ED892AEE9C7700F3D5E2 /* YDSTextFieldProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1371,7 +1423,11 @@
 				956C40192A949BAE0098BB8F /* TypoPageView.swift in Sources */,
 				C7F6908D27DDDA03002B63C9 /* IconsListItemCell.swift in Sources */,
 				B9E4E8C82A90BDB90076473C /* StorybookPageView.swift in Sources */,
+				AF84C5622AF762A400371DB0 /* PasswordTextFieldPageView.swift in Sources */,
 				B9E4E8E22A93B1AF0076473C /* Option.swift in Sources */,
+				AF84C5602AF761AB00371DB0 /* SuffixTextFieldPageView.swift in Sources */,
+				AFEC225F2AEFF56800B062F4 /* SimpleTextFieldPageView.swift in Sources */,
+				AF84C5642AF7638F00371DB0 /* SearchTextFieldPageView.swift in Sources */,
 				5A10B1B82A8F5FFF00139E89 /* IconPageView.swift in Sources */,
 				6CA05E822A90846B00B07920 /* SwiftUIYDSColorArray.swift in Sources */,
 				B9E4E8D62A90BFB60076473C /* OptionalIconOptionView.swift in Sources */,


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- SwiftUI에서 사용 가능한 TextField 시리즈를 구현하였습니다.
- [x] YDS TextField Base
- [x] YDS SimpleTextField
- [x] YDS SearchTextField
- [x] YDS SuffixTextField
- [x] YDS PasswordTextField


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #218 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- TextField의 기본적인 뷰를 추가하기 위해서 Protocol을 작성했는데, 이런식으로 작성하는게 올바를지 같이 얘기해보면 좋을 것 같아요.
- TextField의 Base를 만들어서 각 TextField에서 해당 뷰에 필요한 값만을 넣어주는 형태로 작성했는데 괜찮을지 확인해주세요.
- Base에서는 leading과 trailing에 다양한 타입을 넣어주기 위해서 AnyView를 넣어주고, 각 TextField들에서 AnyView로 래핑해서 보여주는데 어떨지 의견을 공유하면 좋을 것 같아요.
- 

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
<img src = "https://github.com/yourssu/YDS-iOS/assets/96258104/6cb392e2-514c-47b5-b132-af855b705f44" width="30%" height="30%">
