### PR TITLE
[#236] StorybookPage toggle Tint적용

### DIFF
--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/BoolOptionView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/BoolOptionView.swift
@@ -38,6 +38,7 @@ struct BoolOptionView: View {
             }
             Toggle("", isOn: $isOn)
                 .labelsHidden()
+                .tint(YDSColor.buttonPoint)
         }
     }
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
```swift
struct BoolOptionView: View {
    private enum Dimension {
        enum Spacing {
            static let vstack: CGFloat = 8
            static let textSpacing: CGFloat = 4
        }
    }
    
    @Binding private var isOn: Bool
    
    private let description: String?
    
    init(description: String?, isOn: Binding<Bool>) {
        self.description = description
        self._isOn = isOn
    }
    
    var body: some View {
        VStack(alignment: .leading, spacing: Dimension.Spacing.vstack) {
            VStack(alignment: .leading, spacing: Dimension.Spacing.textSpacing) {
                if let description = description {
                    Text(description)
                        .font(YDSFont.subtitle2)
                }
                Text("Bool")
                    .font(YDSFont.body2)
            }
            Toggle("", isOn: $isOn)
                .labelsHidden()
        }
    }
}
```
<img width="50%" alt="스크린샷 2023-11-05 오후 11 54 29" src="https://github.com/yourssu/YDS-iOS/assets/128443511/aca5f75a-66db-4a2d-a964-bc4830a85ab9">

SwiftUI용 StorybookPage의 toggle버튼에 Tint 색상이 적용안된 부분을 수정했습니다


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #236 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->



## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->
<img width="50%" alt="스크린샷 2023-11-06 오전 12 07 53" src="https://github.com/yourssu/YDS-iOS/assets/128443511/771fc011-d5e6-48c2-8fef-8b14592a12d3">


