### PR TITLE
[#226] YDS Bottom Sheet 구현

### DIFF
--- a/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
@@ -32,15 +32,18 @@ struct BottomSheetPageView: View {
     @State var isPresentBottomSheet = false
 
     private var teams: [String] {
-        allTeams[0..<selectedIndex].map { $0.rawValue }
+        switch selectedIndex {
+        case 0...allTeams.count:
+            return allTeams[0..<selectedIndex].map { $0.rawValue }
+        default:
+            return []
+        }
     }
 
     var body: some View {
             StorybookPageView(
                 sample: {
-                    Rectangle()
-                        .fill(Color.clear)
-                        .frame(height: YDSScreenSize.width * 3/4 - 32)
+                    EmptyView()
                 },
                 options: [
                     Option.enum(

--- a/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
@@ -51,7 +51,7 @@ struct BottomSheetPageView: View {
                 ]
             )
             .overlay(alignment: .bottom) {
-                Button(action: { // TODO: 컴포넌트 버튼으로 수정
+                Button(action: { // 컴포넌트 버튼으로 수정 예정
                     isPresentBottomSheet = true
                 }, label: {
                     Text("바텀시트 생성")
@@ -63,8 +63,7 @@ struct BottomSheetPageView: View {
                 content: {
                     VStack(alignment: .leading) {
                         ForEach(teams, id: \.self) { team in
-                            YDSLabel(text: team, typoStyle: String.TypoStyle.title1.font)
-                                .frame(height: 36) // TODO: 이슈 해결 후 수정
+                            YDSLabel(text: team, typoStyle: .title1)
                         }
                     }
                     .frame(maxWidth: .infinity)

--- a/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
@@ -24,6 +24,7 @@ struct BottomSheetPageView: View {
         case four = 4
     }
 
+    private let title = "BottomSheetPageView"
     private let allViews = ExampleCase.allCases
     private let allTeams = YourssuDevTeam.allCases
 
@@ -69,6 +70,7 @@ struct BottomSheetPageView: View {
                     .frame(maxWidth: .infinity)
                 }
             )
+            .navigationTitle(title)
     }
 }
 

--- a/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
@@ -6,10 +6,39 @@
 //
 
 import SwiftUI
+import YDS_SwiftUI
 
 struct BottomSheetPageView: View {
+    private let views = ["zero", "one", "two", "three", "four"]
+
+    @State var selectedIndex = 0
+    @State var isPresentBottomSheet = false
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+            StorybookPageView(
+                sample: {
+                    Rectangle()
+                        .fill(Color.clear)
+                        .frame(height: YDSScreenSize.width * 3/4 - 32)
+                },
+                options: [
+                    Option.enum(
+                        description: "Views",
+                        cases: views,
+                        selectedIndex: $selectedIndex
+                    )
+                ]
+            )
+            .overlay(alignment: .bottom) {
+                // TODO: 컴포넌트 버튼으로 수정
+                Button(action: {
+                    isPresentBottomSheet = true
+                }, label: {
+                    Text("바텀시트 생성")
+                })
+                .padding(.bottom, 32)
+            }
+            .ydsBottomSheet(isPresent: $isPresentBottomSheet)
     }
 }
 

--- a/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
@@ -1,0 +1,20 @@
+//
+//  BottomSheetPageView.swift
+//  YDS-Storybook
+//
+//  Created by 정지혁 on 2023/10/31.
+//
+
+import SwiftUI
+
+struct BottomSheetPageView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct BottomSheetPageView_Previews: PreviewProvider {
+    static var previews: some View {
+        BottomSheetPageView()
+    }
+}

--- a/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BottomSheetPageView.swift
@@ -9,10 +9,30 @@ import SwiftUI
 import YDS_SwiftUI
 
 struct BottomSheetPageView: View {
-    private let views = ["zero", "one", "two", "three", "four"]
+    private enum YourssuDevTeam: String, CaseIterable {
+        case iOS = "iOS"
+        case android = "Android"
+        case backend = "Backend"
+        case frontend = "Frontend"
+    }
+
+    private enum ExampleCase: Int, CaseIterable {
+        case zero = 0
+        case one = 1
+        case two = 2
+        case three = 3
+        case four = 4
+    }
+
+    private let allViews = ExampleCase.allCases
+    private let allTeams = YourssuDevTeam.allCases
 
     @State var selectedIndex = 0
     @State var isPresentBottomSheet = false
+
+    private var teams: [String] {
+        allTeams[0..<selectedIndex].map { $0.rawValue }
+    }
 
     var body: some View {
             StorybookPageView(
@@ -24,21 +44,31 @@ struct BottomSheetPageView: View {
                 options: [
                     Option.enum(
                         description: "Views",
-                        cases: views,
+                        cases: allViews,
                         selectedIndex: $selectedIndex
                     )
                 ]
             )
             .overlay(alignment: .bottom) {
-                // TODO: 컴포넌트 버튼으로 수정
-                Button(action: {
+                Button(action: { // TODO: 컴포넌트 버튼으로 수정
                     isPresentBottomSheet = true
                 }, label: {
                     Text("바텀시트 생성")
                 })
                 .padding(.bottom, 32)
             }
-            .ydsBottomSheet(isPresent: $isPresentBottomSheet)
+            .ydsBottomSheet(
+                isPresent: $isPresentBottomSheet,
+                content: {
+                    VStack(alignment: .leading) {
+                        ForEach(teams, id: \.self) { team in
+                            YDSLabel(text: team, typoStyle: String.TypoStyle.title1.font)
+                                .frame(height: 36) // TODO: 이슈 해결 후 수정
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            )
     }
 }
 

--- a/YDS-Storybook/SwiftUI/PageListView.swift
+++ b/YDS-Storybook/SwiftUI/PageListView.swift
@@ -73,6 +73,9 @@ struct PageListView: View {
         }
         PageView(title: "PasswordTextFieldPageView") {
             PasswordTextFieldPageView()
+		}
+        PageView(title: "BottomSheet") {
+            BottomSheetPageView()
         }
         PageView(title: "Badge") {
             BadgePageView()

--- a/YDS-SwiftUI/Source/Atom/YDSBottomSheet.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSBottomSheet.swift
@@ -1,0 +1,8 @@
+//
+//  YDSBottomSheet.swift
+//  YDS-SwiftUI
+//
+//  Created by 정지혁 on 2023/10/31.
+//
+
+import SwiftUI

--- a/YDS-SwiftUI/Source/Atom/YDSBottomSheet.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSBottomSheet.swift
@@ -6,3 +6,26 @@
 //
 
 import SwiftUI
+
+struct YDSBottomSheet: ViewModifier {
+    @State var height = CGFloat.zero
+
+    @Binding var isPresent: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: $isPresent) {
+                Text("Hello")
+                    .presentationDetents([.medium])
+            }
+    }
+}
+
+extension View {
+    public func ydsBottomSheet(
+        isPresent: Binding<Bool>
+    ) -> some View {
+        self
+            .modifier(YDSBottomSheet(isPresent: isPresent))
+    }
+}

--- a/YDS-SwiftUI/Source/Atom/YDSBottomSheet.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSBottomSheet.swift
@@ -58,10 +58,10 @@ struct YDSBottomSheet<ViewType>: ViewModifier where ViewType: View {
 }
 
 extension View {
-    public func ydsBottomSheet<ViewType>(
+    public func ydsBottomSheet(
         isPresent: Binding<Bool>,
-        content: @escaping () -> ViewType
-    ) -> some View where ViewType: View {
+        content: @escaping () -> some View
+    ) -> some View {
         self
             .modifier(
                 YDSBottomSheet(

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		AFA307202AAAF7CE00916C7E /* YDSProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA3071F2AAAF7CE00916C7E /* YDSProfileImageView.swift */; };
 		AFEC225F2AEFF56800B062F4 /* SimpleTextFieldPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEC225E2AEFF56800B062F4 /* SimpleTextFieldPageView.swift */; };
 		AFFD69422AF1D52400CC8A1B /* YDSTextFieldBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFFD69412AF1D52400CC8A1B /* YDSTextFieldBase.swift */; };
+		B99AFABD2AF0210000AE11CB /* YDSBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99AFABC2AF0210000AE11CB /* YDSBottomSheet.swift */; };
+		B99AFABF2AF0212D00AE11CB /* BottomSheetPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99AFABE2AF0212D00AE11CB /* BottomSheetPageView.swift */; };
 		B9E4E8C82A90BDB90076473C /* StorybookPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */; };
 		B9E4E8CE2A90BF500076473C /* BoolOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */; };
 		B9E4E8D02A90BF7E0076473C /* EnumOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */; };
@@ -381,6 +383,8 @@
 		AFA3071F2AAAF7CE00916C7E /* YDSProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = YDSProfileImageView.swift; path = "YDS-SwiftUI/Source/Atom/YDSProfileImageView.swift"; sourceTree = SOURCE_ROOT; };
 		AFEC225E2AEFF56800B062F4 /* SimpleTextFieldPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTextFieldPageView.swift; sourceTree = "<group>"; };
 		AFFD69412AF1D52400CC8A1B /* YDSTextFieldBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTextFieldBase.swift; sourceTree = "<group>"; };
+		B99AFABC2AF0210000AE11CB /* YDSBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSBottomSheet.swift; sourceTree = "<group>"; };
+		B99AFABE2AF0212D00AE11CB /* BottomSheetPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetPageView.swift; sourceTree = "<group>"; };
 		B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorybookPageView.swift; sourceTree = "<group>"; };
 		B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolOptionView.swift; sourceTree = "<group>"; };
 		B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumOptionView.swift; sourceTree = "<group>"; };
@@ -867,6 +871,7 @@
 				AF23ED7F2AEE9BBB00F3D5E2 /* YDSTextField */,
 				E5E7B6752AF0EDE3005F0B84 /* YDSBadge.swift */,
 				6C9A10B72B3AB8C600757ABC /* YDSTextView.swift */,
+				B99AFABC2AF0210000AE11CB /* YDSBottomSheet.swift */,
 			);
 			path = Atom;
 			sourceTree = "<group>";
@@ -906,6 +911,7 @@
 				AFEC225D2AEFF54500B062F4 /* TextField */,
 				E5E7B6732AF0AAED005F0B84 /* BadgePageView.swift */,
 				6C9A10B92B3B463000757ABC /* TextViewPageView.swift */,
+				B99AFABE2AF0212D00AE11CB /* BottomSheetPageView.swift */,
 			);
 			path = Atom;
 			sourceTree = "<group>";
@@ -1372,6 +1378,7 @@
 				E5E7B6762AF0EDE3005F0B84 /* YDSBadge.swift in Sources */,
 				6F95FE592A768C1E00B398CF /* YDSBasicColor.swift in Sources */,
 				AFFD69422AF1D52400CC8A1B /* YDSTextFieldBase.swift in Sources */,
+				B99AFABD2AF0210000AE11CB /* YDSBottomSheet.swift in Sources */,
 				AFA307202AAAF7CE00916C7E /* YDSProfileImageView.swift in Sources */,
 				6F95FE582A768C1E00B398CF /* YDSSemanticColor.swift in Sources */,
 				80CC69222B0FB08700CDAFA7 /* YDSList.swift in Sources */,
@@ -1501,6 +1508,7 @@
 				C3A8033928AE27E9008E2380 /* NSParagraphStyle.LineBreakStrategy+CustomStringConvertible.swift in Sources */,
 				B9E4E8EC2A97071E0076473C /* ShowPickerButton.swift in Sources */,
 				B9E4E8D42A90BFA10076473C /* OptionalStringOptionView.swift in Sources */,
+				B99AFABF2AF0212D00AE11CB /* BottomSheetPageView.swift in Sources */,
 				537A0ACE26C4188C00142DCE /* DoubleTitleTopBarSampleViewController.swift in Sources */,
 				537FFAA626C3E6F800270C22 /* TopBarSampleViewController.swift in Sources */,
 				C3A8033B28AE2A96008E2380 /* UIModalPresentationStyle+CustomStringConvertible.swift in Sources */,


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
SwiftUI로 Bottom Sheet를 구현했습니다

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #226
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
먼저, SwiftUI의 sheet를 활용해서 현재 디자인과 동일한 Bottom Sheet를 구현하기에 어려운 점이 있었습니다.

단순하게 높이 조절을 하는 presentationDetents()의 경우, iOS 16.0에서 사용이 가능하지만,

배경을 바꾸는 .presentationBackground, cornerRadius를 수정하는 .presentationCornerRadius()의 경우, iOS 16.4부터 대응이 되어 있어, 현재 16.0이 최소 버전인 프로젝트에서 사용할 수 없었습니다.

UIKit과 디자인을 같게 하기 위해, ZStack과 DragGesture를 활용해서 비슷하게 구현을 했지만, sheet 내의 뷰가 미리 로딩이 되어 있는 점, 현재 Storybook처럼 Tabbar가 있을 경우, 대응이 안된다는 문제가 있습니다.

SwiftUI를 활용한 다른 방식으로 구현해도 비슷한 문제가 있고, UIKit으로 구현하면 SwiftUI를 쓰는게 의미가 없어지는 것 같아, 어떻게 처리하면 좋을까요? 

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
https://developer.apple.com/documentation/swiftui/view/presentationbackground(alignment:content:)
https://developer.apple.com/documentation/swiftui/view/presentationcornerradius(_:)

## 🔥 Test
<!-- Test -->
<img width="179" alt="80C09627-EB43-4E98-ABE3-E637C344F44D-removebg-preview" src="https://github.com/yourssu/YDS-iOS/assets/103025692/c38aeda9-b766-40d2-95d1-5c10422855d3">

