### PR TITLE
[#255] SwiftUI용 TextView 구현

### DIFF
--- a/YDS-Storybook/SwiftUI/Atom/LabelPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/LabelPageView.swift
@@ -29,7 +29,7 @@ import YDS_SwiftUI
                 GeometryReader { geometry in
                     YDSLabel(
                         text: text ?? "",
-                        typoStyle: YDSLabel.TypoStyle.allCases[typoStyleSelectedIndex],
+                        typoStyle: YDSLabel.LabelTypoStyle.allCases[typoStyleSelectedIndex],
                         textColor: selectedColor,
                         maxWidth: geometry.size.width - 32,
                         numberOfLines: int,

--- a/YDS-Storybook/SwiftUI/Atom/TextViewPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/TextViewPageView.swift
@@ -1,0 +1,111 @@
+//
+//  TextViewPageView.swift
+//  YDS-Storybook
+//
+//  Created by 오동규 on 12/27/23.
+//
+
+import SwiftUI
+import YDS_SwiftUI
+
+struct TextViewPageView: View {
+    let title: String = "TextView"
+
+    @State var text: String = ""
+    @State var textColorSelectedIndex: Int = 0
+    @State var placeholderText: String? = "댓글을 입력해주세요."
+    @State var placeholderTextColorSelectedIndex: Int = 2
+    @State var multilineTextAlignmentSelectedIndex: Int = 0
+    @State var textViewTextIsEmpty: Bool = true
+
+    var selectedTextColor: Color {
+        return YDSSwiftUIColorWrapper.textColors.items[textColorSelectedIndex].color ?? YDSColor.textPrimary
+    }
+
+    var selectedPlaceholderTextColor: Color {
+        return YDSSwiftUIColorWrapper.textColors.items[placeholderTextColorSelectedIndex].color ?? YDSColor.textTertiary
+    }
+
+    var selectedMultilineTextAlignment: TextAlignment {
+        return TextAlignment.allCases[multilineTextAlignmentSelectedIndex]
+    }
+
+    public var body: some View {
+        StorybookPageView(sample: {
+            GeometryReader { geometry in
+                VStack {
+                    Spacer()
+                    HStack {
+                        YDSProfileImageView(image: Image("profileImageSample1"),
+                                            size: .medium)
+                        Spacer()
+                        YDSTextView(
+                            text: $text,
+                            textColor: selectedTextColor,
+                            placeholderText: placeholderText,
+                            placeholderTextColor: selectedPlaceholderTextColor,
+                            style: .body1,
+                            multilineTextAlignment: selectedMultilineTextAlignment,
+                            minHeight: 35,
+                            maxHeight: 150)
+                        .clipped()
+                        Spacer()
+                        YDSPlainButton(rightIcon: YDSIcon.penFilled,
+                                       size: .medium)
+                    }
+                    .padding(.horizontal, 15)
+                    .padding(.bottom, 15)
+                    Text("TextView.text.isEmpty")
+                        .font(YDSFont.subtitle2)
+                        .foregroundColor(YDSColor.textPrimary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, 25)
+                    if ( text.isEmpty ) {
+                        Text("true")
+                            .font(YDSFont.body2)
+                            .foregroundColor(YDSColor.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 25)
+                    } else {
+                        Text("false")
+                            .font(YDSFont.body2)
+                            .foregroundColor(YDSColor.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 25)
+                    }
+                }
+                .padding(.bottom, 10)
+            }
+            .background(YDSColor.inputFieldElevated)
+        }, options: [
+            Option.enum(
+                description: "textColor",
+                cases: YDSSwiftUIColorWrapper.textColors.items,
+                selectedIndex: $textColorSelectedIndex),
+            Option.optionalString(
+                description: "placeholderText",
+                text: $placeholderText),
+            Option.enum(
+                description: "placeholderTextColor",
+                cases: YDSSwiftUIColorWrapper.textColors.items,
+                selectedIndex: $placeholderTextColorSelectedIndex),
+            Option.enum(
+                description: "multilineTextAlignment",
+                cases: TextAlignment.allCases,
+                selectedIndex: $multilineTextAlignmentSelectedIndex)
+        ])
+    }
+}
+
+#Preview {
+    TextViewPageView()
+}
+
+extension String.SwiftUITypoStyle {
+    public static var allCases: [String.SwiftUITypoStyle] = [.display1, .display2,
+                                                             .title1, .title2, .title3,
+                                                             .subtitle1, .subtitle2, .subtitle3,
+                                                             .body1, .body2,
+                                                             .button0, .button1, .button2, .button3, .button4,
+                                                             .caption0, .caption1, .caption2]
+}

--- a/YDS-Storybook/SwiftUI/Atom/TextViewPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/TextViewPageView.swift
@@ -16,7 +16,6 @@ struct TextViewPageView: View {
     @State var placeholderText: String? = "댓글을 입력해주세요."
     @State var placeholderTextColorSelectedIndex: Int = 2
     @State var multilineTextAlignmentSelectedIndex: Int = 0
-    @State var textViewTextIsEmpty: Bool = true
 
     var selectedTextColor: Color {
         return YDSSwiftUIColorWrapper.textColors.items[textColorSelectedIndex].color ?? YDSColor.textPrimary
@@ -32,50 +31,40 @@ struct TextViewPageView: View {
 
     public var body: some View {
         StorybookPageView(sample: {
-            GeometryReader { geometry in
-                VStack {
+            VStack {
+                Spacer()
+                HStack {
+                    YDSProfileImageView(image: Image("profileImageSample1"),
+                                        size: .medium)
                     Spacer()
-                    HStack {
-                        YDSProfileImageView(image: Image("profileImageSample1"),
-                                            size: .medium)
-                        Spacer()
-                        YDSTextView(
-                            text: $text,
-                            textColor: selectedTextColor,
-                            placeholderText: placeholderText,
-                            placeholderTextColor: selectedPlaceholderTextColor,
-                            style: .body1,
-                            multilineTextAlignment: selectedMultilineTextAlignment,
-                            minHeight: 35,
-                            maxHeight: 150)
-                        .clipped()
-                        Spacer()
-                        YDSPlainButton(rightIcon: YDSIcon.penFilled,
-                                       size: .medium)
-                    }
-                    .padding(.horizontal, 15)
-                    .padding(.bottom, 15)
-                    Text("TextView.text.isEmpty")
-                        .font(YDSFont.subtitle2)
-                        .foregroundColor(YDSColor.textPrimary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.leading, 25)
-                    if ( text.isEmpty ) {
-                        Text("true")
-                            .font(YDSFont.body2)
-                            .foregroundColor(YDSColor.textSecondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 25)
-                    } else {
-                        Text("false")
-                            .font(YDSFont.body2)
-                            .foregroundColor(YDSColor.textSecondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 25)
-                    }
+                    YDSTextView(
+                        text: $text,
+                        textColor: selectedTextColor,
+                        placeholderText: placeholderText,
+                        placeholderTextColor: selectedPlaceholderTextColor,
+                        typoStyle: .body1,
+                        multilineTextAlignment: selectedMultilineTextAlignment,
+                        maxHeight: 150
+                    )
+                    .clipped()
+                    Spacer()
+                    YDSPlainButton(rightIcon: YDSIcon.penFilled,
+                                   size: .medium)
                 }
-                .padding(.bottom, 10)
+                .padding(.horizontal, 15)
+                .padding(.bottom, 15)
+                Text("TextView.text.isEmpty")
+                    .font(YDSFont.subtitle2)
+                    .foregroundColor(YDSColor.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading, 25)
+                Text(text.isEmpty ? "true" : "false")
+                    .font(YDSFont.body2)
+                    .foregroundColor(YDSColor.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading, 25)
             }
+            .padding(.bottom, 10)
             .background(YDSColor.inputFieldElevated)
         }, options: [
             Option.enum(
@@ -99,13 +88,4 @@ struct TextViewPageView: View {
 
 #Preview {
     TextViewPageView()
-}
-
-extension String.SwiftUITypoStyle {
-    public static var allCases: [String.SwiftUITypoStyle] = [.display1, .display2,
-                                                             .title1, .title2, .title3,
-                                                             .subtitle1, .subtitle2, .subtitle3,
-                                                             .body1, .body2,
-                                                             .button0, .button1, .button2, .button3, .button4,
-                                                             .caption0, .caption1, .caption2]
 }

--- a/YDS-Storybook/SwiftUI/PageListView.swift
+++ b/YDS-Storybook/SwiftUI/PageListView.swift
@@ -77,6 +77,9 @@ struct PageListView: View {
         PageView(title: "Badge") {
             BadgePageView()
         }
+        PageView(title: "TextView") {
+            TextViewPageView()
+        }
     }
 
     @ViewBuilder

--- a/YDS-SwiftUI/Source/Atom/YDSLabel.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSLabel.swift
@@ -18,7 +18,7 @@ public struct YDSLabel: UIViewRepresentable {
     let alignment: NSTextAlignment?
     let lineBreakStrategy: NSParagraphStyle.LineBreakStrategy?
 
-    public enum TypoStyle: CaseIterable {
+    public enum LabelTypoStyle: CaseIterable {
         case display1
         case display2
 
@@ -86,7 +86,7 @@ public struct YDSLabel: UIViewRepresentable {
     }
 
     public init(text: String,
-                typoStyle: TypoStyle = .body1,
+                typoStyle: LabelTypoStyle = .body1,
                 textColor: Color = Color.black,
                 maxWidth: CGFloat = .greatestFiniteMagnitude,
                 numberOfLines: Int = 0,

--- a/YDS-SwiftUI/Source/Atom/YDSTextView.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextView.swift
@@ -13,7 +13,7 @@ public struct YDSTextView: View {
 
     let textColor: Color
     let placeholderText: String?
-    let placeholderTextColor: Color
+    let placeholderTextColor: Color?
     let style: String.SwiftUITypoStyle
     let multilineTextAlignment: TextAlignment
     let minHeight: CGFloat
@@ -22,7 +22,7 @@ public struct YDSTextView: View {
     public init(text: Binding<String>,
                 textColor: Color = YDSColor.textPrimary,
                 placeholderText: String? = "댓글을 입력해주세요.",
-                placeholderTextColor: Color = YDSColor.textTertiary,
+                placeholderTextColor: Color? = YDSColor.textTertiary,
                 style: String.SwiftUITypoStyle = .body1,
                 multilineTextAlignment: TextAlignment = .leading,
                 minHeight: CGFloat,

--- a/YDS-SwiftUI/Source/Atom/YDSTextView.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 public struct YDSTextView: View {
     @Binding var text: String
-//    @State var size = CGSize(width: 0.0, height: 0.0)
 
     let textColor: Color
     let placeholderText: String?

--- a/YDS-SwiftUI/Source/Atom/YDSTextView.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextView.swift
@@ -1,0 +1,38 @@
+//
+//  YDSTextView.swift
+//  YDS-SwiftUI
+//
+//  Created by 오동규 on 12/26/23.
+//
+
+import SwiftUI
+
+public struct YDSTextView: View {
+//    let text: String?
+    @State private var text: String? = ""
+    let textColor: Color
+    let placeholderText: String?
+    let placeholderTextColor: Color
+    let style: String.TypoStyle
+    let multilineTextAlignment: TextAlignment
+    let maxHeight: CGFloat?
+
+    public init(text: String? = nil,
+    )
+
+
+
+
+        public var body: some View {
+            VStack {
+                TextEditor(text: $text)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                    .border(Color.gray) // 선택적으로 테두리 설정 가능
+            }
+        }
+}
+
+#Preview {
+    YDSTextView()
+}

--- a/YDS-SwiftUI/Source/Atom/YDSTextView.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextView.swift
@@ -8,31 +8,52 @@
 import SwiftUI
 
 public struct YDSTextView: View {
-//    let text: String?
-    @State private var text: String? = ""
+    @Binding var text: String
+    @State var size = CGSize(width: 0.0, height: 0.0)
+
     let textColor: Color
     let placeholderText: String?
     let placeholderTextColor: Color
-    let style: String.TypoStyle
+    let style: String.SwiftUITypoStyle
     let multilineTextAlignment: TextAlignment
+    let minHeight: CGFloat
     let maxHeight: CGFloat?
 
-    public init(text: String? = nil,
-    )
+    public init(text: Binding<String>,
+                textColor: Color = YDSColor.textPrimary,
+                placeholderText: String? = "댓글을 입력해주세요.",
+                placeholderTextColor: Color = YDSColor.textTertiary,
+                style: String.SwiftUITypoStyle = .body1,
+                multilineTextAlignment: TextAlignment = .leading,
+                minHeight: CGFloat,
+                maxHeight: CGFloat? = nil) {
+        self._text = text
+        self.textColor = textColor
+        self.placeholderText = placeholderText
+        self.placeholderTextColor = placeholderTextColor
+        self.style = style
+        self.multilineTextAlignment = multilineTextAlignment
+        self.minHeight = minHeight
+        self.maxHeight = maxHeight
+    }
 
+    public var body: some View {
+        ZStack(alignment: .topLeading) {
+            TextEditor(text: $text)
+                .foregroundColor(textColor)
+                .font(style.font)
+                .multilineTextAlignment(multilineTextAlignment)
+                .frame(minHeight: minHeight, maxHeight: maxHeight)
+                .fixedSize(horizontal: false, vertical: true)
 
-
-
-        public var body: some View {
-            VStack {
-                TextEditor(text: $text)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
-                    .border(Color.gray) // 선택적으로 테두리 설정 가능
+            if text.isEmpty {
+                Text(placeholderText ?? "")
+                    .foregroundColor(placeholderTextColor)
+                    .font(style.font)
+                    .allowsHitTesting(false)
+                    .padding(.top, 7)
+                    .padding(.leading, 5)
             }
         }
-}
-
-#Preview {
-    YDSTextView()
+    }
 }

--- a/YDS-SwiftUI/Source/Atom/YDSTextView.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextView.swift
@@ -14,44 +14,41 @@ public struct YDSTextView: View {
     let textColor: Color
     let placeholderText: String?
     let placeholderTextColor: Color
-    let style: String.SwiftUITypoStyle
+    let typoStyle: String.SwiftUITypoStyle
     let multilineTextAlignment: TextAlignment
-    let minHeight: CGFloat
     let maxHeight: CGFloat?
 
     public init(text: Binding<String>,
                 textColor: Color = YDSColor.textPrimary,
-                placeholderText: String? = "댓글을 입력해주세요.",
+                placeholderText: String? = nil,
                 placeholderTextColor: Color = YDSColor.textTertiary,
-                style: String.SwiftUITypoStyle,
+                typoStyle: String.SwiftUITypoStyle = .body1,
                 multilineTextAlignment: TextAlignment = .leading,
-                minHeight: CGFloat,
-                maxHeight: CGFloat? = nil) {
+                maxHeight: CGFloat? = nil
+                ) {
         self._text = text
         self.textColor = textColor
         self.placeholderText = placeholderText
         self.placeholderTextColor = placeholderTextColor
-        self.style = style
+        self.typoStyle = typoStyle
         self.multilineTextAlignment = multilineTextAlignment
-        self.minHeight = minHeight
         self.maxHeight = maxHeight
     }
 
     public var body: some View {
-        ZStack(alignment: .topLeading) {
+        ZStack(alignment: .leading) {
             TextEditor(text: $text)
                 .foregroundColor(textColor)
-                .font(style.font)
+                .font(typoStyle.font)
                 .multilineTextAlignment(multilineTextAlignment)
-                .frame(minHeight: minHeight, maxHeight: maxHeight)
+                .frame(minHeight: 35, maxHeight: maxHeight)
                 .fixedSize(horizontal: false, vertical: true)
 
             if text.isEmpty {
                 Text(placeholderText ?? "")
                     .foregroundColor(placeholderTextColor)
-                    .font(style.font)
+                    .font(typoStyle.font)
                     .allowsHitTesting(false)
-                    .padding(.top, 7)
                     .padding(.leading, 5)
             }
         }

--- a/YDS-SwiftUI/Source/Atom/YDSTextView.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 public struct YDSTextView: View {
     @Binding var text: String
-    @State var size = CGSize(width: 0.0, height: 0.0)
+//    @State var size = CGSize(width: 0.0, height: 0.0)
 
     let textColor: Color
     let placeholderText: String?

--- a/YDS-SwiftUI/Source/Atom/YDSTextView.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextView.swift
@@ -13,7 +13,7 @@ public struct YDSTextView: View {
 
     let textColor: Color
     let placeholderText: String?
-    let placeholderTextColor: Color?
+    let placeholderTextColor: Color
     let style: String.SwiftUITypoStyle
     let multilineTextAlignment: TextAlignment
     let minHeight: CGFloat
@@ -22,8 +22,8 @@ public struct YDSTextView: View {
     public init(text: Binding<String>,
                 textColor: Color = YDSColor.textPrimary,
                 placeholderText: String? = "댓글을 입력해주세요.",
-                placeholderTextColor: Color? = YDSColor.textTertiary,
-                style: String.SwiftUITypoStyle = .body1,
+                placeholderTextColor: Color = YDSColor.textTertiary,
+                style: String.SwiftUITypoStyle,
                 multilineTextAlignment: TextAlignment = .leading,
                 minHeight: CGFloat,
                 maxHeight: CGFloat? = nil) {

--- a/YDS-SwiftUI/Source/Foundation/YDSTypoStyle.swift
+++ b/YDS-SwiftUI/Source/Foundation/YDSTypoStyle.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension String {
-    enum TypoStyle {
+    public enum SwiftUITypoStyle {
         case display1
         case display2
 

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		5A10B1B62A8F5C8500139E89 /* SwiftUIYDSIconArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A10B1B52A8F5C8500139E89 /* SwiftUIYDSIconArray.swift */; };
 		5A10B1B82A8F5FFF00139E89 /* IconPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A10B1B72A8F5FFF00139E89 /* IconPageView.swift */; };
 		6C9A10B82B3AB8C600757ABC /* YDSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C9A10B72B3AB8C600757ABC /* YDSTextView.swift */; };
+		6C9A10BA2B3B463000757ABC /* TextViewPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C9A10B92B3B463000757ABC /* TextViewPageView.swift */; };
 		6CA05E822A90846B00B07920 /* SwiftUIYDSColorArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA05E812A90846B00B07920 /* SwiftUIYDSColorArray.swift */; };
 		6F2D527B2A79446000BAF200 /* ColorPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2D527A2A79446000BAF200 /* ColorPageView.swift */; };
 		6F2D527D2A7944D800BAF200 /* PageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2D527C2A7944D800BAF200 /* PageListView.swift */; };
@@ -330,6 +331,7 @@
 		5A10B1B52A8F5C8500139E89 /* SwiftUIYDSIconArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIYDSIconArray.swift; sourceTree = "<group>"; };
 		5A10B1B72A8F5FFF00139E89 /* IconPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPageView.swift; sourceTree = "<group>"; };
 		6C9A10B72B3AB8C600757ABC /* YDSTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTextView.swift; sourceTree = "<group>"; };
+		6C9A10B92B3B463000757ABC /* TextViewPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewPageView.swift; sourceTree = "<group>"; };
 		6CA05E812A90846B00B07920 /* SwiftUIYDSColorArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIYDSColorArray.swift; sourceTree = "<group>"; };
 		6F2D527A2A79446000BAF200 /* ColorPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPageView.swift; sourceTree = "<group>"; };
 		6F2D527C2A7944D800BAF200 /* PageListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListView.swift; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 				026BCF1E2B02619C00AE91E9 /* PlainButtonPageView.swift */,
 				AFEC225D2AEFF54500B062F4 /* TextField */,
 				E5E7B6732AF0AAED005F0B84 /* BadgePageView.swift */,
+				6C9A10B92B3B463000757ABC /* TextViewPageView.swift */,
 			);
 			path = Atom;
 			sourceTree = "<group>";
@@ -1454,6 +1457,7 @@
 				537FFAA426C3E5C200270C22 /* TopBarPageViewController.swift in Sources */,
 				C3AFE2E2289FB1FA007D391D /* BottomSheetPageViewController.swift in Sources */,
 				53E26E8826F061F80036648E /* TypographiesListTableViewController.swift in Sources */,
+				6C9A10BA2B3B463000757ABC /* TextViewPageView.swift in Sources */,
 				53E2CF3C26D29F62000DE005 /* SimpleTextFieldViewPageViewController.swift in Sources */,
 				5365FD5B274A4ED000B6FBF9 /* IntControllerView.swift in Sources */,
 				029935502AEF84D400F46712 /* BoxButtonPageView.swift in Sources */,

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		53EFF5D426BBC26900732DCF /* ToastPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53EFF5D326BBC26900732DCF /* ToastPageViewController.swift */; };
 		5A10B1B62A8F5C8500139E89 /* SwiftUIYDSIconArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A10B1B52A8F5C8500139E89 /* SwiftUIYDSIconArray.swift */; };
 		5A10B1B82A8F5FFF00139E89 /* IconPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A10B1B72A8F5FFF00139E89 /* IconPageView.swift */; };
+		6C9A10B82B3AB8C600757ABC /* YDSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C9A10B72B3AB8C600757ABC /* YDSTextView.swift */; };
 		6CA05E822A90846B00B07920 /* SwiftUIYDSColorArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA05E812A90846B00B07920 /* SwiftUIYDSColorArray.swift */; };
 		6F2D527B2A79446000BAF200 /* ColorPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2D527A2A79446000BAF200 /* ColorPageView.swift */; };
 		6F2D527D2A7944D800BAF200 /* PageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2D527C2A7944D800BAF200 /* PageListView.swift */; };
@@ -328,6 +329,7 @@
 		53EFF5D326BBC26900732DCF /* ToastPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastPageViewController.swift; sourceTree = "<group>"; };
 		5A10B1B52A8F5C8500139E89 /* SwiftUIYDSIconArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIYDSIconArray.swift; sourceTree = "<group>"; };
 		5A10B1B72A8F5FFF00139E89 /* IconPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPageView.swift; sourceTree = "<group>"; };
+		6C9A10B72B3AB8C600757ABC /* YDSTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSTextView.swift; sourceTree = "<group>"; };
 		6CA05E812A90846B00B07920 /* SwiftUIYDSColorArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIYDSColorArray.swift; sourceTree = "<group>"; };
 		6F2D527A2A79446000BAF200 /* ColorPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPageView.swift; sourceTree = "<group>"; };
 		6F2D527C2A7944D800BAF200 /* PageListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListView.swift; sourceTree = "<group>"; };
@@ -859,6 +861,7 @@
 				026BCF202B0261BA00AE91E9 /* YDSPlainButton.swift */,
 				AF23ED7F2AEE9BBB00F3D5E2 /* YDSTextField */,
 				E5E7B6752AF0EDE3005F0B84 /* YDSBadge.swift */,
+				6C9A10B72B3AB8C600757ABC /* YDSTextView.swift */,
 			);
 			path = Atom;
 			sourceTree = "<group>";
@@ -1373,6 +1376,7 @@
 				6F956F1E2A8D5F560023D0E3 /* Exported.swift in Sources */,
 				AF23ED812AEE9BF600F3D5E2 /* YDSSimpleTextField.swift in Sources */,
 				AF1E6F002AB88DEB0071C963 /* YDSToast.swift in Sources */,
+				6C9A10B82B3AB8C600757ABC /* YDSTextView.swift in Sources */,
 				951261322AB969560012B5F9 /* YDSLabel.swift in Sources */,
 				026BCF212B0261BA00AE91E9 /* YDSPlainButton.swift in Sources */,
 				AF23ED892AEE9C7700F3D5E2 /* YDSTextFieldProtocol.swift in Sources */,


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
SwiftUI용 TextView 구현
UIRepresentable 을 이용해 개발하다가 한계점을 깨닫고 SwiftUI의 TextEditor를 사용하여 YDSTextView를 구현하였습니다.

인자에는 textColor, placeholderText, placeholderTextColor, style, multilineTextAlignment, multilineTextAlignment, minHeight, maxHeight가 있습니다.
SwiftUI에서는 Font 사이즈를 측정하는 방법이 없기에 글자 크기에 맞는 TextEditor의 높이를 자동으로 설정해주지 못해 인자 중에 style과 minHeight는 필수로  사용자가 크기에 맞게 인자로 넣어줘야 합니다. 

그리고 TextEditor에는 제공되는 placeholder가 없어 직접 Text를 띄워 만들어주었습니다. 더 좋은 방법이 있다면 알려주세요.

또한 옵션으로는 multilineTextAlignment가 추가되었고, SwiftUI TextEditor에는 사용이 불가능한 NSlinebreakmode는 추가하지 않았습니다.

현재 발생하는 버그는 하나 있습니다. maxHeight를 설정해줬을때 TextEditor의 크기는 알맞게 최대 사이즈가 설정되지만 그 안에 들어가는 입력 값의 맨 마지막 줄 까지 스크롤이 되지 않는 버그입니다. 고치려고 해봤지만 잘 되지 않아요. 도움을 주세요..ㅜㅜ

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->


https://github.com/yourssu/YDS-iOS/assets/103497527/522f4280-da95-436f-8b78-474d9e3b08f0






