### PR TITLE
[#258] SwiftUI StorybookPageView 다크모드 대응

### DIFF
--- a/YDS-Storybook/SwiftUI/Atom/BadgePageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BadgePageView.swift
@@ -33,7 +33,7 @@ struct BadgePageView: View {
                     .frame(maxWidth: .infinity, maxHeight: YDSScreenSize.width * 3/4)
                     .background(
                         Rectangle()
-                            .fill(.white) //뱃지의 색과 배경색이 같아 임의로 하얀색으로 조정했습니다.
+                            .fill(YDSColor.bgNormal)
                     )
                 }
             }

--- a/YDS-Storybook/SwiftUI/Atom/EmojiButtonPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/EmojiButtonPageView.swift
@@ -24,10 +24,6 @@ struct EmojiButtonPageView: View {
                                    text: text,
                                    isSelected: $isSelected)
                     .frame(maxWidth: .infinity, maxHeight: YDSScreenSize.width * 3/4)
-                    .background(
-                        Rectangle()
-                            .fill(.white)
-                    )
                 }
             }
 

--- a/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
@@ -61,7 +61,7 @@ private extension StorybookPageView {
             .frame(maxWidth: .infinity, maxHeight: YDSScreenSize.width * 3/4)
             .background(
                 Rectangle()
-                    .fill(Color.white)
+                    .fill(YDSColor.monoItemBG)
             )
     }
 

--- a/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
@@ -9,23 +9,23 @@ import SwiftUI
 
 import YDS_SwiftUI
 
-struct OptionListItem: View {
-    private enum Dimension {
-        enum Spacing {
-            static let vstack: CGFloat = 16
-        }
-        
-        enum Padding {
-            static let vstack: CGFloat = 16
-        }
+private enum Dimension {
+    enum Spacing {
+        static let vstack: CGFloat = 16
     }
-    
+
+    enum Padding {
+        static let vstack: CGFloat = 16
+    }
+}
+
+struct OptionListItem: View {
     private let option: Option
-    
+
     init(option: Option) {
         self.option = option
     }
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: Dimension.Spacing.vstack) {
             option.body
@@ -37,14 +37,14 @@ struct OptionListItem: View {
 
 struct StorybookPageView<ViewType: View>: View {
     @ViewBuilder private var sample: () -> ViewType
-    
+
     private let options: [Option]
-    
+
     init(sample: @escaping () -> ViewType, options: [Option]) {
         self.sample = sample
         self.options = options
     }
-    
+
     var body: some View {
         VStack(spacing: 0) {
             sampleExpaned
@@ -64,7 +64,7 @@ private extension StorybookPageView {
                     .fill(Color.white)
             )
     }
-    
+
     var scrollableOptions: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -92,7 +92,7 @@ struct StorybookPageView_Previews: PreviewProvider {
 
         return StorybookPageView(
             sample: {
-                Button(action: {}) {
+                Button {} label: {
                     HStack {
                         if let icon = icon?.icon {
                             icon
@@ -106,7 +106,11 @@ struct StorybookPageView_Previews: PreviewProvider {
             options: [
                 Option.bool(description: "isDisabled", isOn: $isDisabled),
                 Option.int(description: "numberOfLines", value: $numberOfLines),
-                Option.enum(description: "buttonType", cases: BoxButtonType.allCases, selectedIndex: $selectedBoxButtonType),
+                Option.enum(
+                    description: "buttonType",
+                    cases: BoxButtonType.allCases,
+                    selectedIndex: $selectedBoxButtonType
+                ),
                 Option.optionalString(description: "text", text: $text),
                 Option.optionalIcon(description: "icon", icons: icons, selectedIcon: $icon)
             ]


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
StorybookPageView 내의 샘플 화면의 배경색을 수정했습니다(Color.white -> YDSColor.monoItemBG).
일부 Lint 문제를 해결했습니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #258
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
간단하게 샘플 화면의 배경색을 수정한 PR입니다.
<STRIKE>일부 배경색을 수정한 화면에는 적용되지 않았습니다(EmojiButton, BadgeView). 이 부분의 수정도 현재 브랜치에 포함되야 할 내용일까요?</STRIKE>
BadgePageView에서 배경색을 UIKit과 동일하게 bgNormal로 수정했고,
EmojiButtonPageView에서 배경색을 삭제해서 다크모드 대응을 했습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
<img width=300 src=https://github.com/yourssu/YDS-iOS/assets/103025692/f37e8a28-b8a1-4d5f-8231-5a75e6cba26b />
<img width=300 src=https://github.com/yourssu/YDS-iOS/assets/103025692/a93017de-8422-41af-8bb5-55a0c83ea0f0 />
<img width=300 src=https://github.com/yourssu/YDS-iOS/assets/103025692/f1bbac97-0b51-4717-8204-eb1f117807de />
<img width=300 src=https://github.com/yourssu/YDS-iOS/assets/103025692/2777fd36-1749-4865-8164-8906b2136dc0 />
