### PR TITLE
[#251] SwiftUI BoxButton, PlainButton 수정

### DIFF
--- a/YDS-Storybook/SwiftUI/Atom/BadgePageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BadgePageView.swift
@@ -44,7 +44,7 @@ struct BadgePageView: View {
             Option.optionalIcon(
                 description: "icon",
                 icons: YDSSwiftUIIcon.icons,
-                selectedIcon: $icons),
+                selectedIcon: $icons, placeholderIndex: 0),
             Option.enum(
                 description: "color",
                 cases: YDSItemColor.allCases,

--- a/YDS-Storybook/SwiftUI/Atom/BoxButtonPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BoxButtonPageView.swift
@@ -43,11 +43,11 @@ public struct BoxButtonPageView: View {
             Option.optionalIcon(
                 description: "leftIcon",
                 icons: YDSSwiftUIIcon.icons,
-                selectedIcon: $leftIcon),
+                selectedIcon: $leftIcon, placeholderIndex: 56),
             Option.optionalIcon(
                 description: "rightIcon",
                 icons: YDSSwiftUIIcon.icons,
-                selectedIcon: $rightIcon),
+                selectedIcon: $rightIcon, placeholderIndex: 56),
             Option.enum(
                 description: "type",
                 cases: YDSBoxButton.BoxButtonType.allCases,

--- a/YDS-Storybook/SwiftUI/Atom/BoxButtonPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BoxButtonPageView.swift
@@ -23,16 +23,21 @@ public struct BoxButtonPageView: View {
 
     public var body: some View {
         StorybookPageView(sample: {
-            YDSBoxButton(
-                text: text,
-                leftIcon: leftIcon?.icon,
-                rightIcon: rightIcon?.icon,
-                type: YDSBoxButton.BoxButtonType.allCases[typeSelectedIndex],
-                size: YDSBoxButton.BoxButtonSize.allCases[sizeSelectedIndex],
-                rounding: YDSBoxButton.BoxButtonRounding.allCases[roundingSelectedIndex],
-                isDisabled: isDisabled,
-                isWarned: isWarned
-            )
+            Button(action: {
+                print("YDSBoxButton Click!!")
+            }, label: {
+                YDSBoxButton(
+                    text: text,
+                    leftIcon: leftIcon?.icon,
+                    rightIcon: rightIcon?.icon,
+                    type: YDSBoxButton.BoxButtonType.allCases[typeSelectedIndex],
+                    size: YDSBoxButton.BoxButtonSize.allCases[sizeSelectedIndex],
+                    rounding: YDSBoxButton.BoxButtonRounding.allCases[roundingSelectedIndex],
+                    isDisabled: isDisabled,
+                    isWarned: isWarned
+                )
+            })
+            .disabled(isDisabled)
             .frame(height: YDSScreenSize.width * 3/4 - 32)
             .padding(16)
             .clipped()

--- a/YDS-Storybook/SwiftUI/Atom/BoxButtonPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/BoxButtonPageView.swift
@@ -23,24 +23,18 @@ public struct BoxButtonPageView: View {
 
     public var body: some View {
         StorybookPageView(sample: {
-            Button(action: {
-                print("YDSBoxButton Click!!")
-            }, label: {
-                YDSBoxButton(
-                    text: text,
-                    leftIcon: leftIcon?.icon,
-                    rightIcon: rightIcon?.icon,
-                    type: YDSBoxButton.BoxButtonType.allCases[typeSelectedIndex],
-                    size: YDSBoxButton.BoxButtonSize.allCases[sizeSelectedIndex],
-                    rounding: YDSBoxButton.BoxButtonRounding.allCases[roundingSelectedIndex],
-                    isDisabled: isDisabled,
-                    isWarned: isWarned
-                )
-            })
-            .disabled(isDisabled)
-            .frame(height: YDSScreenSize.width * 3/4 - 32)
-            .padding(16)
-            .clipped()
+            YDSBoxButton(
+                text: text,
+                leftIcon: leftIcon?.icon,
+                rightIcon: rightIcon?.icon,
+                type: YDSBoxButton.BoxButtonType.allCases[typeSelectedIndex],
+                size: YDSBoxButton.BoxButtonSize.allCases[sizeSelectedIndex],
+                rounding: YDSBoxButton.BoxButtonRounding.allCases[roundingSelectedIndex],
+                isDisabled: isDisabled,
+                isWarned: isWarned,
+                action: {
+                    print("This is YDSBoxButton.")
+                })
         }, options: [
             Option.optionalString(
                 description: "text",

--- a/YDS-Storybook/SwiftUI/Atom/PlainButtonPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/PlainButtonPageView.swift
@@ -11,6 +11,8 @@ import YDS_SwiftUI
 struct PlainButtonPageView: View {
     let title: String = "PlainButtonView"
 
+    @State private var isPressed = false
+
     @State var text: String? = "재생"
     @State var int: Int = 0
     @State var leftIcon: SwiftUIIcon? = YDSSwiftUIIcon.icons[56]
@@ -22,15 +24,20 @@ struct PlainButtonPageView: View {
 
     public var body: some View {
         StorybookPageView(sample: {
-            YDSPlainButton(
-                text: text,
-                leftIcon: leftIcon?.icon,
-                rightIcon: rightIcon?.icon,
-                size: YDSPlainButton.PlainButtonSize.allCases[sizeSelectedIndex],
-                isDisabled: isDisabled,
-                isWarned: isWarned,
-                isPointed: isPointed
-            )
+            Button(action: {
+                print("YDSPlainButton Click!!")
+            }, label: {
+                YDSPlainButton(
+                    text: text,
+                    leftIcon: leftIcon?.icon,
+                    rightIcon: rightIcon?.icon,
+                    size: YDSPlainButton.PlainButtonSize.allCases[sizeSelectedIndex],
+                    isDisabled: isDisabled,
+                    isWarned: isWarned,
+                    isPointed: isPointed
+                )
+            })
+            .disabled(isDisabled)
             .frame(height: YDSScreenSize.width * 3/4 - 32)
             .padding(16)
             .clipped()

--- a/YDS-Storybook/SwiftUI/Atom/PlainButtonPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/PlainButtonPageView.swift
@@ -24,23 +24,17 @@ struct PlainButtonPageView: View {
 
     public var body: some View {
         StorybookPageView(sample: {
-            Button(action: {
-                print("YDSPlainButton Click!!")
-            }, label: {
-                YDSPlainButton(
-                    text: text,
-                    leftIcon: leftIcon?.icon,
-                    rightIcon: rightIcon?.icon,
-                    size: YDSPlainButton.PlainButtonSize.allCases[sizeSelectedIndex],
-                    isDisabled: isDisabled,
-                    isWarned: isWarned,
-                    isPointed: isPointed
-                )
-            })
-            .disabled(isDisabled)
-            .frame(height: YDSScreenSize.width * 3/4 - 32)
-            .padding(16)
-            .clipped()
+            YDSPlainButton(
+                text: text,
+                leftIcon: leftIcon?.icon,
+                rightIcon: rightIcon?.icon,
+                size: YDSPlainButton.PlainButtonSize.allCases[sizeSelectedIndex],
+                isDisabled: isDisabled,
+                isWarned: isWarned,
+                isPointed: isPointed,
+                action: {
+                    print("This is YDSPlainButton.")
+                })
         }, options: [
             Option.optionalString(
                 description: "text",

--- a/YDS-Storybook/SwiftUI/Atom/PlainButtonPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/PlainButtonPageView.swift
@@ -41,11 +41,11 @@ struct PlainButtonPageView: View {
             Option.optionalIcon(
                 description: "leftIcon",
                 icons: YDSSwiftUIIcon.icons,
-                selectedIcon: $leftIcon),
+                selectedIcon: $leftIcon, placeholderIndex: 56),
             Option.optionalIcon(
                 description: "rightIcon",
                 icons: YDSSwiftUIIcon.icons,
-                selectedIcon: $rightIcon),
+                selectedIcon: $rightIcon, placeholderIndex: 56),
             Option.enum(
                 description: "size",
                 cases: YDSPlainButton.PlainButtonSize.allCases,

--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/Base/Option.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/Base/Option.swift
@@ -12,7 +12,7 @@ enum Option: View {
     case `enum`(description: String?, cases: [Any], selectedIndex: Binding<Int>)
     case int(description: String?, value: Binding<Int>)
     case optionalString(description: String?, text: Binding<String?>)
-    case optionalIcon(description: String?, icons: [SwiftUIIcon], selectedIcon: Binding<SwiftUIIcon?>)
+    case optionalIcon(description: String?, icons: [SwiftUIIcon], selectedIcon: Binding<SwiftUIIcon?>, placeholderIndex: Int)
     case optionalImage(description: String?, images: [SwiftUIImage], selectedImage: Binding<SwiftUIImage?>)
 
     @ViewBuilder
@@ -26,8 +26,8 @@ enum Option: View {
             IntOptionView(description: description, value: value)
         case .optionalString(let description, let text):
             OptionalStringOptionView(description: description, text: text)
-        case .optionalIcon(let description, let icons, let selectedIcon):
-            OptionalIconOptionView(description: description, icons: icons, selectedIcon: selectedIcon)
+        case .optionalIcon(let description, let icons, let selectedIcon, let placeholderIndex):
+            OptionalIconOptionView(description: description, icons: icons, selectedIcon: selectedIcon, placeholderIndex: placeholderIndex)
         case .optionalImage(let description, let images, let selectedImage):
             OptionalImageOptionView(description: description, images: images, selectedImage: selectedImage)
         }

--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalIconOptionView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalIconOptionView.swift
@@ -32,11 +32,11 @@ struct OptionalIconOptionView: View {
     @State private var placeholderIndex: Int
     @State private var isPresentPicker = false
 
-    init(description: String?, icons: [SwiftUIIcon], selectedIcon: Binding<SwiftUIIcon?>) {
+    init(description: String?, icons: [SwiftUIIcon], selectedIcon: Binding<SwiftUIIcon?>, placeholderIndex: Int) {
         self.description = description
         self.icons = icons
         self._selectedIcon = selectedIcon
-        self.placeholderIndex = 0
+        self.placeholderIndex = placeholderIndex
     }
     
     var body: some View {
@@ -76,7 +76,7 @@ struct OptionalIconOptionView_Previews: PreviewProvider {
         OptionalIconOptionView(
             description: "icon",
             icons: YDSSwiftUIIcon.icons,
-            selectedIcon: .constant(YDSSwiftUIIcon.icons[0])
+            selectedIcon: .constant(YDSSwiftUIIcon.icons[0]), placeholderIndex: 0
         )
     }
 }

--- a/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
@@ -108,7 +108,7 @@ struct StorybookPageView_Previews: PreviewProvider {
                 Option.int(description: "numberOfLines", value: $numberOfLines),
                 Option.enum(description: "buttonType", cases: BoxButtonType.allCases, selectedIndex: $selectedBoxButtonType),
                 Option.optionalString(description: "text", text: $text),
-                Option.optionalIcon(description: "icon", icons: icons, selectedIcon: $icon)
+                Option.optionalIcon(description: "icon", icons: icons, selectedIcon: $icon, placeholderIndex: 0)
             ]
         )
     }

--- a/YDS-SwiftUI/Source/Atom/YDSBoxButton.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSBoxButton.swift
@@ -146,6 +146,8 @@ public struct YDSBoxButton: View {
         case r4 = 4
     }
 
+    let action: () -> Void
+
     public init(text: String? = nil,
                 leftIcon: Image? = nil,
                 rightIcon: Image? = nil,
@@ -153,7 +155,8 @@ public struct YDSBoxButton: View {
                 size: BoxButtonSize = .small,
                 rounding: BoxButtonRounding = .r4,
                 isDisabled: Bool = false,
-                isWarned: Bool = false
+                isWarned: Bool = false,
+                action: @escaping () -> Void
     ) {
         self.text = text
         self.leftIcon = leftIcon
@@ -163,47 +166,51 @@ public struct YDSBoxButton: View {
         self.rounding = rounding
         self.isDisabled = isDisabled
         self.isWarned = isWarned
+        self.action = action
     }
 
     public var body: some View {
-        HStack(spacing: 4) {
-            if let leftIcon {
-                leftIcon
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: size.iconSize, height: size.iconSize)
-                    .foregroundColor(pointColor(for: type))
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if let leftIcon {
+                    leftIcon
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: size.iconSize, height: size.iconSize)
+                        .foregroundColor(pointColor(for: type))
+                }
+                if let text {
+                    Text(text)
+                        .font(size.font)
+                }
+                if let rightIcon {
+                    rightIcon
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: size.iconSize, height: size.iconSize)
+                        .foregroundColor(pointColor(for: type))
+                }
             }
-            if let text {
-                Text(text)
-                    .font(size.font)
-            }
-            if let rightIcon {
-                rightIcon
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: size.iconSize, height: size.iconSize)
-                    .foregroundColor(pointColor(for: type))
-            }
-        }
-        .padding(.vertical, size.padding)
-        .padding(.horizontal, size.padding)
-        .frame(height: size.height)
-        .foregroundColor(pointColor(for: type))
-        .background(backgroundColor(for: type))
-        .disabled(isDisabled)
-        .cornerRadius(rounding.rawValue)
-        .overlay(
-            RoundedRectangle(cornerRadius: rounding.rawValue)
-                .stroke(borderColor(for: type) ?? Color.clear)
-        )
+            .padding(.vertical, size.padding)
+            .padding(.horizontal, size.padding)
+            .frame(height: size.height)
+            .foregroundColor(pointColor(for: type))
+            .background(backgroundColor(for: type))
+            .cornerRadius(rounding.rawValue)
+            .overlay(
+                RoundedRectangle(cornerRadius: rounding.rawValue)
+                    .stroke(borderColor(for: type) ?? Color.clear)
+            )
+        }.disabled(isDisabled)
     }
 }
 
 struct YDSBoxButton_Previews: PreviewProvider {
     static var previews: some View {
-        YDSBoxButton()
+        YDSBoxButton(action: {
+            print("YDSBoxButton tapped!")
+        })
     }
 }

--- a/YDS-SwiftUI/Source/Atom/YDSBoxButton.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSBoxButton.swift
@@ -166,42 +166,39 @@ public struct YDSBoxButton: View {
     }
 
     public var body: some View {
-        Button {
-
-        } label: {
-            HStack(spacing: 4) {
-                if let leftIcon {
-                    leftIcon
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: size.iconSize, height: size.iconSize)
-                        .foregroundColor(pointColor(for: type))
-                }
-                if let text {
-                    Text(text)
-                        .font(size.font)
-                }
-                if let rightIcon {
-                    rightIcon
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: size.iconSize, height: size.iconSize)
-                        .foregroundColor(pointColor(for: type))
-                }
+        HStack(spacing: 4) {
+            if let leftIcon {
+                leftIcon
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: size.iconSize, height: size.iconSize)
+                    .foregroundColor(pointColor(for: type))
             }
-            .padding(.vertical, size.padding)
-            .padding(.horizontal, size.padding)
-            .frame(height: size.height)
-            .foregroundColor(pointColor(for: type))
-            .background(backgroundColor(for: type))
-            .cornerRadius(rounding.rawValue)
-            .overlay(
-                RoundedRectangle(cornerRadius: rounding.rawValue)
-                    .stroke(borderColor(for: type) ?? Color.clear)
-            )
-        }.disabled(isDisabled)
+            if let text {
+                Text(text)
+                    .font(size.font)
+            }
+            if let rightIcon {
+                rightIcon
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: size.iconSize, height: size.iconSize)
+                    .foregroundColor(pointColor(for: type))
+            }
+        }
+        .padding(.vertical, size.padding)
+        .padding(.horizontal, size.padding)
+        .frame(height: size.height)
+        .foregroundColor(pointColor(for: type))
+        .background(backgroundColor(for: type))
+        .disabled(isDisabled)
+        .cornerRadius(rounding.rawValue)
+        .overlay(
+            RoundedRectangle(cornerRadius: rounding.rawValue)
+                .stroke(borderColor(for: type) ?? Color.clear)
+        )
     }
 }
 

--- a/YDS-SwiftUI/Source/Atom/YDSPlainButton.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSPlainButton.swift
@@ -62,7 +62,7 @@ public struct YDSPlainButton: View {
             case .large:
                 return YDSFont.button2
             case .medium:
-                return YDSFont.button2
+                return YDSFont.button3
             case .small:
                 return YDSFont.button4
             }
@@ -73,7 +73,7 @@ public struct YDSPlainButton: View {
             case .large:
                 return 24
             case .medium:
-                return 24
+                return 20
             case .small:
                 return 16
             }
@@ -103,36 +103,33 @@ public struct YDSPlainButton: View {
     }
 
     public var body: some View {
-        Button {
-
-        } label: {
-            HStack(spacing: 4) {
-                if let leftIcon {
-                    leftIcon
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: size.iconSize, height: size.iconSize)
-                        .foregroundColor(pointColor())
-                }
-                if let text {
-                    Text(text)
-                        .font(size.font)
-                }
-                if let rightIcon {
-                    rightIcon
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: size.iconSize, height: size.iconSize)
-                        .foregroundColor(pointColor())
-                }
+        HStack(spacing: 4) {
+            if let leftIcon {
+                leftIcon
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: size.iconSize, height: size.iconSize)
+                    .foregroundColor(pointColor())
             }
-            .padding(.vertical, size.padding)
-            .padding(.horizontal, size.padding)
-            .frame(height: size.height)
-            .foregroundColor(pointColor())
-        }.disabled(isDisabled)
+            if let text {
+                Text(text)
+                    .font(size.font)
+            }
+            if let rightIcon {
+                rightIcon
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: size.iconSize, height: size.iconSize)
+                    .foregroundColor(pointColor())
+            }
+        }
+        .padding(.vertical, size.padding)
+        .padding(.horizontal, size.padding)
+        .frame(height: size.height)
+        .foregroundColor(pointColor())
+        .disabled(isDisabled)
     }
 }
 

--- a/YDS-SwiftUI/Source/Atom/YDSPlainButton.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSPlainButton.swift
@@ -17,7 +17,7 @@ public struct YDSPlainButton: View {
     let isDisabled: Bool
     let isWarned: Bool
     let isPointed: Bool
-
+    
     fileprivate func pointColor() -> Color? {
         if isDisabled {
             return YDSColor.buttonDisabled
@@ -29,12 +29,12 @@ public struct YDSPlainButton: View {
             return YDSColor.buttonNormal
         }
     }
-
+    
     public enum PlainButtonSize {
         case large
         case medium
         case small
-
+        
         fileprivate var height: CGFloat {
             switch self {
             case .large:
@@ -45,7 +45,7 @@ public struct YDSPlainButton: View {
                 return 32
             }
         }
-
+        
         fileprivate var padding: CGFloat {
             switch self {
             case .large:
@@ -56,7 +56,7 @@ public struct YDSPlainButton: View {
                 return 12
             }
         }
-
+        
         fileprivate var font: Font {
             switch self {
             case .large:
@@ -67,7 +67,7 @@ public struct YDSPlainButton: View {
                 return YDSFont.button4
             }
         }
-
+        
         fileprivate var iconSize: CGFloat {
             switch self {
             case .large:
@@ -79,19 +79,22 @@ public struct YDSPlainButton: View {
             }
         }
     }
-
+    
     public enum BoxButtonRounding: CGFloat {
         case r8 = 8
         case r4 = 4
     }
-
+    
+    let action: () -> Void
+    
     public init(text: String? = nil,
                 leftIcon: Image? = nil,
                 rightIcon: Image? = nil,
                 size: PlainButtonSize = .small,
                 isDisabled: Bool = false,
                 isWarned: Bool = false,
-                isPointed: Bool = false
+                isPointed: Bool = false,
+                action: @escaping () -> Void
     ) {
         self.text = text
         self.leftIcon = leftIcon
@@ -100,41 +103,45 @@ public struct YDSPlainButton: View {
         self.isDisabled = isDisabled
         self.isWarned = isWarned
         self.isPointed = isPointed
+        self.action = action
     }
-
+    
     public var body: some View {
-        HStack(spacing: 4) {
-            if let leftIcon {
-                leftIcon
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: size.iconSize, height: size.iconSize)
-                    .foregroundColor(pointColor())
+        Button(action: action){
+            HStack(spacing: 4) {
+                if let leftIcon {
+                    leftIcon
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: size.iconSize, height: size.iconSize)
+                        .foregroundColor(pointColor())
+                }
+                if let text {
+                    Text(text)
+                        .font(size.font)
+                }
+                if let rightIcon {
+                    rightIcon
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: size.iconSize, height: size.iconSize)
+                        .foregroundColor(pointColor())
+                }
             }
-            if let text {
-                Text(text)
-                    .font(size.font)
-            }
-            if let rightIcon {
-                rightIcon
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: size.iconSize, height: size.iconSize)
-                    .foregroundColor(pointColor())
-            }
-        }
-        .padding(.vertical, size.padding)
-        .padding(.horizontal, size.padding)
-        .frame(height: size.height)
-        .foregroundColor(pointColor())
-        .disabled(isDisabled)
+            .padding(.vertical, size.padding)
+            .padding(.horizontal, size.padding)
+            .frame(height: size.height)
+            .foregroundColor(pointColor())
+        }.disabled(isDisabled)
     }
 }
 
 struct YDSPlainButton_Previews: PreviewProvider {
     static var previews: some View {
-        YDSPlainButton()
+        YDSPlainButton(action: {
+            print("YDSPlainButton tapped!")
+        })
     }
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- SwiftUI PlainButton, BoxButton default 아이콘 변경
- SwiftUI PlainButton medium 옵션 수정
- button action 추가 가능하게 만들기


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #251 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
앞으로 BoxButton이나 PlainButton에 Click Event 추가하시려면 아래와 같은 코드로 사용하시면 됩니다!
```swift
            YDSBoxButton(
                text: text,
                leftIcon: leftIcon?.icon,
                rightIcon: rightIcon?.icon,
                type: YDSBoxButton.BoxButtonType.allCases[typeSelectedIndex],
                size: YDSBoxButton.BoxButtonSize.allCases[sizeSelectedIndex],
                rounding: YDSBoxButton.BoxButtonRounding.allCases[roundingSelectedIndex],
                isDisabled: isDisabled,
                isWarned: isWarned,
                action: {
                    print("This is YDSBoxButton.")
                })
```

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

## 🔥 Test
<!-- Test -->

https://github.com/yourssu/YDS-iOS/assets/78733700/4d6805cb-249e-40d2-9b3f-d2089566b714