### PR TITLE
[#255] YDSLabel SwiftUI로 리팩토링

### DIFF
--- a/YDS-Storybook/SwiftUI/Atom/LabelPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/LabelPageView.swift
@@ -13,7 +13,7 @@ import YDS_SwiftUI
 
     @State var text: String? = "Label"
     @State var typoStyleSelectedIndex = 0
-    @State var lineLimit: Int? = nil
+    @State var lineLimit: Int?
     @State var textColorSelectedIndex: Int = 0
     @State var alignmentSelectedIndex: Int = 1
     @State var truncationModeSelectedIndex: Int = 2
@@ -38,7 +38,7 @@ import YDS_SwiftUI
             VStack {
                 YDSLabel(
                     text: text,
-                    style: selectedTypoStyle,
+                    font: selectedTypoStyle,
                     lineLimit: lineLimit,
                     textColor: selectedColor,
                     alignment: selectedAlignment,

--- a/YDS-Storybook/SwiftUI/Atom/LabelPageView.swift
+++ b/YDS-Storybook/SwiftUI/Atom/LabelPageView.swift
@@ -12,35 +12,39 @@ import YDS_SwiftUI
     let title: String = "Label"
 
     @State var text: String? = "Label"
-    @State var int: Int = 0
     @State var typoStyleSelectedIndex = 0
+    @State var lineLimit: Int? = nil
     @State var textColorSelectedIndex: Int = 0
-    @State var lineBreakModeSelectedIndex: Int = 0
     @State var alignmentSelectedIndex: Int = 1
-    @State var lineBreakStrategySelectedIndex: Int = 2
+    @State var truncationModeSelectedIndex: Int = 2
+    @State var isAllowsTightening: Bool = false
 
-    var selectedColor: Color { return YDSSwiftUIColorWrapper.textColors.items[textColorSelectedIndex].color
-        ?? .black }
-    var selectedTypoStyle: Font { return Font(String.TypoStyle.allCases[typoStyleSelectedIndex].font) }
+    var selectedTypoStyle: Font {
+        return Font(String.TypoStyle.allCases[typoStyleSelectedIndex].font)
+    }
+    var selectedColor: Color {
+        return YDSSwiftUIColorWrapper.textColors.items[textColorSelectedIndex].color
+        ?? .black
+    }
+    var selectedAlignment: TextAlignment {
+        return TextAlignment.allCases[alignmentSelectedIndex]
+    }
+    var selectedTruncationMode: Text.TruncationMode {
+        return Text.TruncationMode.allCases[truncationModeSelectedIndex]
+    }
 
     public var body: some View {
         StorybookPageView(sample: {
             VStack {
-                GeometryReader { geometry in
-                    YDSLabel(
-                        text: text ?? "",
-                        typoStyle: YDSLabel.LabelTypoStyle.allCases[typoStyleSelectedIndex],
-                        textColor: selectedColor,
-                        maxWidth: geometry.size.width - 32,
-                        numberOfLines: int,
-                        lineBreakMode: NSLineBreakMode.allCases[lineBreakModeSelectedIndex],
-                        alignment: NSTextAlignment.allCases[alignmentSelectedIndex],
-                        lineBreakStrategy: NSParagraphStyle.LineBreakStrategy.allCases[lineBreakStrategySelectedIndex]
-                    )
-                    .frame(height: YDSScreenSize.width * 3/4 - 32)
-                    .padding(16)
-                    .clipped()
-                }
+                YDSLabel(
+                    text: text,
+                    style: selectedTypoStyle,
+                    lineLimit: lineLimit,
+                    textColor: selectedColor,
+                    alignment: selectedAlignment,
+                    truncationMode: selectedTruncationMode,
+                    allowsTightening: isAllowsTightening
+                )
             }
         }, options: [
             Option.optionalString(
@@ -50,30 +54,29 @@ import YDS_SwiftUI
                 description: "style",
                 cases: String.TypoStyle.allCases,
                 selectedIndex: $typoStyleSelectedIndex),
-            Option.int(description: "numberOfLines", value: $int),
+            Option.optionalInt(
+                description: "lineLimit",
+                value: $lineLimit),
             Option.enum(
                 description: "textColor",
                 cases: YDSSwiftUIColorWrapper.textColors.items,
                 selectedIndex: $textColorSelectedIndex),
             Option.enum(
-                description: "lineBreakMode",
-                cases: NSLineBreakMode.allCases,
-                selectedIndex: $lineBreakModeSelectedIndex),
-            Option.enum(
                 description: "alignment",
-                cases: NSTextAlignment.allCases,
+                cases: TextAlignment.allCases,
                 selectedIndex: $alignmentSelectedIndex),
             Option.enum(
-                description: "lineBreakStrategy",
-                cases: NSParagraphStyle.LineBreakStrategy.allCases,
-                selectedIndex: $lineBreakStrategySelectedIndex)
+                description: "truncationMode",
+                cases: Text.TruncationMode.allCases,
+                selectedIndex: $truncationModeSelectedIndex),
+            Option.bool(
+                description: "allowsTightening",
+                isOn: $isAllowsTightening)
         ])
         .navigationTitle(title)
     }
 }
 
-struct LabelPageView_Previews: PreviewProvider {
-    static var previews: some View {
-        LabelPageView()
-    }
+#Preview {
+    LabelPageView()
 }

--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/Base/Option.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/Base/Option.swift
@@ -10,7 +10,7 @@ import SwiftUI
 enum Option: View {
     case bool(description: String?, isOn: Binding<Bool>)
     case `enum`(description: String?, cases: [Any], selectedIndex: Binding<Int>)
-    case int(description: String?, value: Binding<Int>)
+    case optionalInt(description: String?, value: Binding<Int?>)
     case optionalString(description: String?, text: Binding<String?>)
     case optionalIcon(description: String?, icons: [SwiftUIIcon], selectedIcon: Binding<SwiftUIIcon?>)
     case optionalImage(description: String?, images: [SwiftUIImage], selectedImage: Binding<SwiftUIImage?>)
@@ -22,8 +22,8 @@ enum Option: View {
             BoolOptionView(description: description, isOn: isOn)
         case .enum(let description, let cases, let selectedIndex):
             EnumOptionView(description: description, cases: cases, selectedIndex: selectedIndex)
-        case .int(let description, let value):
-            IntOptionView(description: description, value: value)
+        case .optionalInt(let description, let value):
+            OptionalIntOptionView(description: description, value: value)
         case .optionalString(let description, let text):
             OptionalStringOptionView(description: description, text: text)
         case .optionalIcon(let description, let icons, let selectedIcon):

--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalIntOptionView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalIntOptionView.swift
@@ -1,14 +1,14 @@
 //
-//  IntOptionView.swift
+//  OptionalIntOptionView.swift
 //  YDS-Storybook
 //
-//  Created by 정지혁 on 2023/08/19.
+//  Created by 박지윤 on 1/16/24.
 //
 
 import SwiftUI
 import YDS_SwiftUI
 
-struct IntOptionView: View {
+struct OptionalIntOptionView: View {
     private enum Dimension {
         enum Spacing {
             static let vstack: CGFloat = 8
@@ -24,11 +24,11 @@ struct IntOptionView: View {
         }
     }
     
-    @Binding private var value: Int
+    @Binding private var value: Int?
     
     private let description: String?
     
-    init(description: String?, value: Binding<Int>) {
+    init(description: String?, value: Binding<Int?>) {
         self.description = description
         self._value = value
     }
@@ -40,7 +40,7 @@ struct IntOptionView: View {
                     Text(description)
                         .font(YDSFont.subtitle2)
                 }
-                Text("Int")
+                Text("Optional<Int>")
                     .font(YDSFont.body2)
             }
             
@@ -56,8 +56,8 @@ struct IntOptionView: View {
     }
 }
 
-struct IntOptionView_Previews: PreviewProvider {
+struct OptionalIntOptionView_Previews: PreviewProvider {
     static var previews: some View {
-        IntOptionView(description: "numberOfLines", value: .constant(1))
+        OptionalIntOptionView(description: "lineLimit", value: .constant(1))
     }
 }

--- a/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalStringOptionView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/OptionView/OptionalStringOptionView.swift
@@ -27,7 +27,8 @@ struct OptionalStringOptionView: View {
     @Binding private var text: String?
     
     private let description: String?
-    
+
+    @State private var isToggleOn = true
     @State private var placeholder: String
     
     init(description: String?, text: Binding<String?>) {
@@ -54,6 +55,7 @@ struct OptionalStringOptionView: View {
                     },
                     set: { isOn in
                         isOn ? (text = placeholder) : (text = nil)
+                        self.isToggleOn = isOn
                     }
                 ))
                 .labelsHidden()
@@ -72,6 +74,7 @@ struct OptionalStringOptionView: View {
             .font(YDSFont.body1)
             .tint(YDSColor.textPointed)
             .padding(Dimension.Padding.button)
+            .foregroundColor(isToggleOn ? YDSColor.bgNormalDark : YDSColor.bgDimDark)
             .background(
                 RoundedRectangle(cornerRadius: Dimension.Rectangle.cornerRadius)
                     .fill(YDSColor.inputFieldElevated)

--- a/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
+++ b/YDS-Storybook/SwiftUI/Storybook/StorybookPageView.swift
@@ -86,7 +86,7 @@ struct StorybookPageView_Previews: PreviewProvider {
 
         @State var text: String? = "BoxButton"
         @State var isDisabled = false
-        @State var numberOfLines = 1
+        @State var lineLimit: Int? = 1
         @State var selectedBoxButtonType = 0
         @State var icon: SwiftUIIcon?
 
@@ -98,14 +98,14 @@ struct StorybookPageView_Previews: PreviewProvider {
                             icon
                         }
                         Text(text ?? "")
-                            .lineLimit(numberOfLines)
+                            .lineLimit(lineLimit)
                     }
                 }
                 .disabled(isDisabled)
             },
             options: [
                 Option.bool(description: "isDisabled", isOn: $isDisabled),
-                Option.int(description: "numberOfLines", value: $numberOfLines),
+                Option.optionalInt(description: "lineLimit", value: $lineLimit),
                 Option.enum(
                     description: "buttonType",
                     cases: BoxButtonType.allCases,

--- a/YDS-SwiftUI/Source/Atom/YDSLabel.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSLabel.swift
@@ -8,123 +8,51 @@
 import SwiftUI
 import YDS_Essential
 
-public struct YDSLabel: UIViewRepresentable {
+extension Text.TruncationMode {
+    public static var allCases: [Text.TruncationMode] = [.head, .middle, .tail]
+}
+
+public struct YDSLabel: View {
     let text: String?
-    let typoStyle: UIFont?
-    let textColor: Color?
-    let maxWidth: CGFloat?
-    let numberOfLines: Int?
-    let lineBreakMode: NSLineBreakMode?
-    let alignment: NSTextAlignment?
-    let lineBreakStrategy: NSParagraphStyle.LineBreakStrategy?
+    let style: Font
+    let lineLimit: Int?
+    let textColor: Color
+    let alignment: TextAlignment
+    let truncationMode: Text.TruncationMode
+    let allowsTightening: Bool
 
-    public enum LabelTypoStyle: CaseIterable {
-        case display1
-        case display2
+    public init(text: String? = "Label",
+                style: Font = YDSFont.display1,
+                lineLimit: Int? = nil,
+                textColor: Color = YDSColor.textPrimary,
+                alignment: TextAlignment = .center,
+                truncationMode: Text.TruncationMode = .tail,
+                allowsTightening: Bool = false
+    ) {
+        self.text = text
+        self.style = style
+        self.lineLimit = lineLimit
+        self.textColor = textColor
+        self.alignment = alignment
+        self.truncationMode = truncationMode
+        self.allowsTightening = allowsTightening
+    }
 
-        case title1
-        case title2
-        case title3
-
-        case subtitle1
-        case subtitle2
-        case subtitle3
-
-        case body1
-        case body2
-
-        case button0
-        case button1
-        case button2
-        case button3
-        case button4
-
-        case caption0
-        case caption1
-        case caption2
-
-        var uiFont: UIFont {
-            switch self {
-            case .display1:
-                return UIFont.systemFont(ofSize: 40, weight: .bold )
-            case .display2:
-                return UIFont.systemFont(ofSize: 32, weight: .bold )
-            case .title1:
-                return UIFont.systemFont(ofSize: 28, weight: .bold )
-            case .title2:
-                return UIFont.systemFont(ofSize: 24, weight: .bold )
-            case .title3:
-                return UIFont.systemFont(ofSize: 20, weight: .bold )
-            case .subtitle1:
-                return UIFont.systemFont(ofSize: 20, weight: .semibold )
-            case .subtitle2:
-                return UIFont.systemFont(ofSize: 16, weight: .semibold )
-            case .subtitle3:
-                return UIFont.systemFont(ofSize: 14, weight: .semibold )
-            case .body1:
-                return UIFont.systemFont(ofSize: 15, weight: .regular )
-            case .body2:
-                return UIFont.systemFont(ofSize: 14, weight: .regular )
-            case .button0:
-                return UIFont.systemFont(ofSize: 16, weight: .medium )
-            case .button1:
-                return UIFont.systemFont(ofSize: 16, weight: .semibold )
-            case .button2:
-                return UIFont.systemFont(ofSize: 14, weight: .semibold )
-            case .button3:
-                return UIFont.systemFont(ofSize: 14, weight: .regular )
-            case .button4:
-                return UIFont.systemFont(ofSize: 12, weight: .medium )
-            case .caption0:
-                return UIFont.systemFont(ofSize: 12, weight: .semibold )
-            case .caption1:
-                return UIFont.systemFont(ofSize: 12, weight: .regular )
-            case .caption2:
-                return UIFont.systemFont(ofSize: 11, weight: .regular )
-            }
+    public var body: some View {
+        if let text = text {
+            Text(text)
+                .font(style)
+                .lineLimit(lineLimit)
+                .foregroundColor(textColor)
+                .multilineTextAlignment(alignment)
+                .truncationMode(truncationMode)
+                .allowsTightening(allowsTightening)
         }
     }
+}
 
-    public init(text: String,
-                typoStyle: LabelTypoStyle = .body1,
-                textColor: Color = Color.black,
-                maxWidth: CGFloat = .greatestFiniteMagnitude,
-                numberOfLines: Int = 0,
-                lineBreakMode: NSLineBreakMode = .byWordWrapping,
-                alignment: NSTextAlignment = .center,
-                lineBreakStrategy: NSParagraphStyle.LineBreakStrategy = .hangulWordPriority) {
-        self.text = text
-        self.typoStyle = typoStyle.uiFont
-        self.textColor = textColor
-        self.maxWidth = maxWidth
-        self.numberOfLines = numberOfLines
-        self.lineBreakMode = lineBreakMode
-        self.alignment = alignment
-        self.lineBreakStrategy = lineBreakStrategy
-    }
-
-    public func makeUIView(context: Context) -> UILabel {
-        let label = UILabel()
-        label.text = text
-        label.font = typoStyle
-        label.textColor = UIColor(textColor ?? .black)
-        label.numberOfLines = numberOfLines ?? 0
-        label.lineBreakMode = lineBreakMode ?? .byWordWrapping
-        label.textAlignment = alignment ?? .center
-        label.lineBreakStrategy = lineBreakStrategy ?? .hangulWordPriority
-        label.preferredMaxLayoutWidth = maxWidth ?? .greatestFiniteMagnitude
-
-        return label
-    }
-
-    public func updateUIView(_ uiView: UILabel, context: Context) {
-        uiView.text = text
-        uiView.font = typoStyle
-        uiView.textColor = UIColor(textColor ?? .black)
-        uiView.numberOfLines = numberOfLines ?? 0
-        uiView.lineBreakMode = lineBreakMode ?? .byWordWrapping
-        uiView.textAlignment = alignment ?? .center
-        uiView.lineBreakStrategy = lineBreakStrategy ?? .hangulWordPriority
-        uiView.setContentHuggingPriority(.defaultHigh, for: .vertical)
+struct YDSLabel_Previews: PreviewProvider {
+    static var previews: some View {
+        YDSLabel()
     }
 }

--- a/YDS-SwiftUI/Source/Atom/YDSLabel.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSLabel.swift
@@ -14,7 +14,7 @@ extension Text.TruncationMode {
 
 public struct YDSLabel: View {
     let text: String?
-    let style: Font
+    let font: Font
     let lineLimit: Int?
     let textColor: Color
     let alignment: TextAlignment
@@ -22,7 +22,7 @@ public struct YDSLabel: View {
     let allowsTightening: Bool
 
     public init(text: String? = "Label",
-                style: Font = YDSFont.display1,
+                font: Font = YDSFont.display1,
                 lineLimit: Int? = nil,
                 textColor: Color = YDSColor.textPrimary,
                 alignment: TextAlignment = .center,
@@ -30,7 +30,7 @@ public struct YDSLabel: View {
                 allowsTightening: Bool = false
     ) {
         self.text = text
-        self.style = style
+        self.font = font
         self.lineLimit = lineLimit
         self.textColor = textColor
         self.alignment = alignment
@@ -41,7 +41,7 @@ public struct YDSLabel: View {
     public var body: some View {
         if let text = text {
             Text(text)
-                .font(style)
+                .font(font)
                 .lineLimit(lineLimit)
                 .foregroundColor(textColor)
                 .multilineTextAlignment(alignment)

--- a/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
+++ b/YDS-SwiftUI/Source/Atom/YDSTextField/YDSTextFieldBase.swift
@@ -93,7 +93,7 @@ struct YDSTextFieldBase<Leading: View, Trailing: View>: View {
                 YDSLabel(
                     text: fieldText,
                     textColor: fieldTextColor,
-                    alignment: NSTextAlignment.left
+                    alignment: .leading
                 )
             }
 
@@ -132,7 +132,7 @@ struct YDSTextFieldBase<Leading: View, Trailing: View>: View {
                 YDSLabel(
                     text: helperText,
                     textColor: helperTextColor,
-                    alignment: NSTextAlignment.left
+                    alignment: .leading
                 )
                 .padding(.horizontal, 8)
             }

--- a/YDS-SwiftUI/Source/Foundation/YDSTypoStyle.swift
+++ b/YDS-SwiftUI/Source/Foundation/YDSTypoStyle.swift
@@ -103,5 +103,12 @@ extension String {
                 return 1.3
             }
         }
+
+        public static var allCases: [String.TypoStyle] = [.display1, .display2,
+                                                          .title1, .title2, .title3,
+                                                          .subtitle1, .subtitle2, .subtitle3,
+                                                          .body1, .body2,
+                                                          .button0, .button1, .button2, .button3, .button4,
+                                                          .caption0, .caption1, .caption2]
     }
 }

--- a/YDS.xcodeproj/project.pbxproj
+++ b/YDS.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		954C48392B036D5D002F9FAC /* BottomBarControllerPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954C48382B036D5D002F9FAC /* BottomBarControllerPageView.swift */; };
 		956C40172A949B640098BB8F /* SwiftUIYDSTypoArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956C40162A949B640098BB8F /* SwiftUIYDSTypoArray.swift */; };
 		956C40192A949BAE0098BB8F /* TypoPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956C40182A949BAE0098BB8F /* TypoPageView.swift */; };
+		95CC861E2B55A81F0088E44E /* OptionalIntOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CC861D2B55A81F0088E44E /* OptionalIntOptionView.swift */; };
 		95E535C72AB482E200FA2492 /* LabelPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E535C62AB482E200FA2492 /* LabelPageView.swift */; };
 		AF1E6F002AB88DEB0071C963 /* YDSToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1E6EFF2AB88DEB0071C963 /* YDSToast.swift */; };
 		AF23ED812AEE9BF600F3D5E2 /* YDSSimpleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF23ED802AEE9BF600F3D5E2 /* YDSSimpleTextField.swift */; };
@@ -148,7 +149,6 @@
 		B9E4E8C82A90BDB90076473C /* StorybookPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */; };
 		B9E4E8CE2A90BF500076473C /* BoolOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */; };
 		B9E4E8D02A90BF7E0076473C /* EnumOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */; };
-		B9E4E8D22A90BF870076473C /* IntOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8D12A90BF870076473C /* IntOptionView.swift */; };
 		B9E4E8D42A90BFA10076473C /* OptionalStringOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8D32A90BFA10076473C /* OptionalStringOptionView.swift */; };
 		B9E4E8D62A90BFB60076473C /* OptionalIconOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8D52A90BFB60076473C /* OptionalIconOptionView.swift */; };
 		B9E4E8E22A93B1AF0076473C /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E4E8E12A93B1AF0076473C /* Option.swift */; };
@@ -365,6 +365,7 @@
 		954C48382B036D5D002F9FAC /* BottomBarControllerPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomBarControllerPageView.swift; sourceTree = "<group>"; };
 		956C40162A949B640098BB8F /* SwiftUIYDSTypoArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIYDSTypoArray.swift; sourceTree = "<group>"; };
 		956C40182A949BAE0098BB8F /* TypoPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypoPageView.swift; sourceTree = "<group>"; };
+		95CC861D2B55A81F0088E44E /* OptionalIntOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalIntOptionView.swift; sourceTree = "<group>"; };
 		95E535C62AB482E200FA2492 /* LabelPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelPageView.swift; sourceTree = "<group>"; };
 		AF1E6EFF2AB88DEB0071C963 /* YDSToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSToast.swift; sourceTree = "<group>"; };
 		AF23ED802AEE9BF600F3D5E2 /* YDSSimpleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YDSSimpleTextField.swift; sourceTree = "<group>"; };
@@ -384,7 +385,6 @@
 		B9E4E8C72A90BDB90076473C /* StorybookPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorybookPageView.swift; sourceTree = "<group>"; };
 		B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolOptionView.swift; sourceTree = "<group>"; };
 		B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumOptionView.swift; sourceTree = "<group>"; };
-		B9E4E8D12A90BF870076473C /* IntOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntOptionView.swift; sourceTree = "<group>"; };
 		B9E4E8D32A90BFA10076473C /* OptionalStringOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalStringOptionView.swift; sourceTree = "<group>"; };
 		B9E4E8D52A90BFB60076473C /* OptionalIconOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalIconOptionView.swift; sourceTree = "<group>"; };
 		B9E4E8E12A93B1AF0076473C /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
@@ -936,7 +936,7 @@
 				B9E4E8CA2A90BF180076473C /* Base */,
 				B9E4E8CD2A90BF500076473C /* BoolOptionView.swift */,
 				B9E4E8CF2A90BF7E0076473C /* EnumOptionView.swift */,
-				B9E4E8D12A90BF870076473C /* IntOptionView.swift */,
+				95CC861D2B55A81F0088E44E /* OptionalIntOptionView.swift */,
 				B9E4E8D32A90BFA10076473C /* OptionalStringOptionView.swift */,
 				B9E4E8D52A90BFB60076473C /* OptionalIconOptionView.swift */,
 				AF7528232AA5F637001174E7 /* OptionalImageOptionView.swift */,
@@ -1516,6 +1516,7 @@
 				533A27B926A5351E009FD90A /* PageListTableViewCell.swift in Sources */,
 				956C40172A949B640098BB8F /* SwiftUIYDSTypoArray.swift in Sources */,
 				539110B426C049BD0094FD08 /* SingleTitleTopBarPageViewController.swift in Sources */,
+				95CC861E2B55A81F0088E44E /* OptionalIntOptionView.swift in Sources */,
 				6FFDB97D2A7183F7003A9519 /* PickerControllerView.swift in Sources */,
 				5337939026AF0A0600BE5860 /* OptionalStringControllerView.swift in Sources */,
 				5337938E26AF09BF00BE5860 /* ControllerView.swift in Sources */,
@@ -1532,7 +1533,6 @@
 				533A27B326A52E56009FD90A /* PageListViewController.swift in Sources */,
 				532DBFD226EC7323008C2354 /* UITableView+Generic.swift in Sources */,
 				5359A5C526BED19900FCCECC /* DoubleTitleTopBarPageViewController.swift in Sources */,
-				B9E4E8D22A90BF870076473C /* IntOptionView.swift in Sources */,
 				538ACCB426EB40A60044A437 /* ColorsListTableViewController.swift in Sources */,
 				AF7528222AA5F0A1001174E7 /* ProfileImagePageView.swift in Sources */,
 				53441B0426AF287600CB6BC9 /* BoolControllerView.swift in Sources */,


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
1. 기존 UIKit 요소들을 없애고 **SwiftUI**에 정의된 속성 중 최대한 유사한 속성으로 교체해주었습니다.
- numberOfLines -> `lineLimits`
- textAlignment -> `multilineTextAlignment`
- lineBreakMode, lineBreakStrategy -> `truncationMode`, `allowsTightening`
2. 모든 속성을 설정하지 않고도 원하는 속성만 골라 적용할 수 있습니다.
- 설정하지 않은 속성은 기본값으로 적용됩니다.
3. UIKit에서의 numberOfLines = `0`은 SwiftUI에서의 lineLimits = `nil`과 같아 
lineLimits의 기본값을 nil로 설정하기 위해 `IntOptionView`를 `OptionalIntOptionView`로 수정하였습니다.
4. StorybookPageView의 backgroundColor를 기존 스토리북과 동일하게 변경하였습니다.
5. OptionalStringOptionView의 toggle이 false일 때의 placeholder의 색상(foregroundColor)을 변경하였습니다.

<img src="https://github.com/yourssu/YDS-iOS/assets/84546438/5b4dc50c-65a0-48fe-a17f-1bdedc2283fe"  width="200" height="400"/>

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #250 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
[Simulator Screen Recording - iPhone 15 Pro - 2024-01-16 at 03.56.30.mp4.zip](https://github.com/yourssu/YDS-iOS/files/13942246/Simulator.Screen.Recording.-.iPhone.15.Pro.-.2024-01-16.at.03.56.30.mp4.zip)
